### PR TITLE
fix(@embark/ens): connect to web3 only with dappAutoEnable is true

### DIFF
--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -306,7 +306,7 @@ function Contract(options) {
   });
 
   return ContractClass;
-};
+}
 
 Contract.prototype.deploy = function(args, _options) {
   var self = this;

--- a/packages/embarkjs/ens/src/index.js
+++ b/packages/embarkjs/ens/src/index.js
@@ -172,7 +172,9 @@ function connectHttp(web3, endpoint, callback) {
 async function connectWeb3(web3, callback) {
   if (typeof window !== 'undefined' && window.ethereum) {
     try {
-      await ethereum.enable();
+      if (this.dappAutoEnable) {
+        await ethereum.enable();
+      }
       web3.setProvider(ethereum);
       return checkConnection(callback);
     } catch (e) {
@@ -207,6 +209,7 @@ __embarkENS.setProvider = function(config) {
   this.registration = config.registration;
   this.env = config.env;
   this.ready = false;
+  this.dappAutoEnable = config.dappAutoEnable;
 
   reduce(config.dappConnection, false, (result, connectionString, next) => {
     if (result.connected) {

--- a/packages/plugins/ens/src/index.js
+++ b/packages/plugins/ens/src/index.js
@@ -140,6 +140,7 @@ class ENS {
         path: [this.config.embarkConfig.generationDir, 'config'],
         file: 'namesystem.json',
         format: 'json',
+        dappAutoEnable: this.config.contractsConfig.dappAutoEnable,
         content: Object.assign({}, this.embark.config.namesystemConfig, config)
       }, cb);
     });

--- a/packages/plugins/ens/test/index.js
+++ b/packages/plugins/ens/test/index.js
@@ -4,7 +4,7 @@ const {Utils} = require('embarkjs');
 const secureSend = Utils.secureSend;
 
 describe('embark-ens', () => {
-  let ens, doneCb;
+  let ens;
 
   const { embark } = fakeEmbark();
 
@@ -22,8 +22,9 @@ describe('embark-ens', () => {
           rootDomain: 'root.eth'
         },
         dappConnection: []
-      }
-    };
+      },
+      contractsConfig: {dappAutoEnable: true}
+    }
   });
 
   afterEach(() => {
@@ -37,6 +38,7 @@ describe('embark-ens', () => {
           path: ['test-dir', 'config'],
           file: 'namesystem.json',
           format: 'json',
+          dappAutoEnable: true,
           content: Object.assign({}, embark.config.namesystemConfig, config)
         });
         cb();


### PR DESCRIPTION
When we introduced dappConnection to ENS, we didn't add the concept
of auto connection, like we do in the "normal" connection. This
means that when using $WEB3, the contracts connection waited for
the user to click on a button, but the ENS part called `ethereum.enable`
directly, which is confusing for the dev, because we specified to
NOT automatically connect to ethreum.

This fixes it by checking the dappAutoEnable property in contracts
config and adds it to the namesystemConfig artifact