### PR TITLE
build(deps): bump solc from 0.5.0 to 0.6.1

### DIFF
--- a/dapps/templates/boilerplate/embark.json
+++ b/dapps/templates/boilerplate/embark.json
@@ -9,7 +9,7 @@
   "buildDir": "dist/",
   "config": "config/",
   "versions": {
-    "solc": "0.5.0"
+    "solc": "0.6.1"
   },
   "plugins": {
   },

--- a/dapps/templates/demo/contracts/simple_storage.sol
+++ b/dapps/templates/demo/contracts/simple_storage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 contract SimpleStorage {
   uint public storedData;

--- a/dapps/templates/demo/embark.json
+++ b/dapps/templates/demo/embark.json
@@ -9,7 +9,7 @@
   "buildDir": "dist/",
   "config": "config/",
   "versions": {
-    "solc": "0.5.0"
+    "solc": "0.6.1"
   },
   "plugins": {
   },

--- a/dapps/templates/simple/embark.json
+++ b/dapps/templates/simple/embark.json
@@ -10,7 +10,7 @@
     "webserver": false
   },
   "versions": {
-    "solc": "0.5.0"
+    "solc": "0.6.1"
   },
   "plugins": {
   },

--- a/packages/core/core/src/configDefaults.ts
+++ b/packages/core/core/src/configDefaults.ts
@@ -41,7 +41,7 @@ export function getBlockchainDefaults(env) {
 
 export function getContractDefaults(embarkConfigVersions) {
   const defaultVersions = {
-    solc: "0.5.0"
+    solc: "0.6.1"
   };
   const versions = recursiveMerge(defaultVersions, embarkConfigVersions || {});
 

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -112,7 +112,6 @@
     "semver": "5.6.0",
     "shelljs": "0.8.3",
     "simples": "0.8.8",
-    "solc": "0.5.0",
     "source-map-support": "0.5.13",
     "string-replace-async": "1.2.1",
     "term.js": "0.0.7",

--- a/packages/embark/src/test/config.js
+++ b/packages/embark/src/test/config.js
@@ -205,7 +205,7 @@ describe('embark.Config', function () {
     it('should load contract config correctly', function () {
       config.loadContractsConfigFile();
       let expectedConfig = {
-        versions: {solc: '0.5.0'},
+        versions: {solc: '0.6.1'},
         dappConnection: ['$WEB3', 'ws://localhost:8546', 'localhost:8545'],
         dappAutoEnable: true,
         "gas": "400000",
@@ -227,7 +227,7 @@ describe('embark.Config', function () {
 
     it('should replace occurrences of `0x0` with full zero addresses', () => {
       let expectedConfig = {
-        versions: {solc: '0.5.0'},
+        versions: {solc: '0.6.1'},
         dappConnection: ['$WEB3', 'ws://localhost:8546', 'localhost:8545'],
         dappAutoEnable: true,
         "gas": "auto",

--- a/packages/embark/src/test/contracts.js
+++ b/packages/embark/src/test/contracts.js
@@ -5,13 +5,18 @@ import ContractsManager from 'embark-contracts-manager';
 import Compiler from 'embark-compiler';
 import { Logger } from 'embark-logger';
 import { Events, fs, IPC, TestLogger, Plugins } from 'embark-core';
+import findUp from 'find-up';
 let assert = require('assert');
 
 let readFile = function(file) {
   return new File({filename: file, type: Types.dappFile, path: file});
 };
 
-const currentSolcVersion = require('../../package.json').dependencies.solc;
+// will need refactor if we some day switch back to specifying version ranges
+const currentSolcVersion = require(findUp.sync(
+  'node_modules/embark-solidity/package.json',
+  {cwd: __dirname}
+)).dependencies.solc;
 const TestEvents = {
   request: (cmd, cb) => {
     cb(currentSolcVersion);
@@ -50,8 +55,8 @@ describe('embark.Contracts', function() {
       registerAPICall: () => {},
       events: events,
       fs: {
-        existsSync: () => { return false },
-        dappPath: () => { return "ok" }
+        existsSync: () => { return false; },
+        dappPath: () => { return "ok"; }
       },
       logger: plugins.logger,
       embarkConfig: {
@@ -99,14 +104,10 @@ describe('embark.Contracts', function() {
       "gas": "auto",
       "contracts": {
         "Token": {
-          "args": [
-            100
-          ]
+          "args": [100]
         },
         "SimpleStorage": {
-          "args": [
-            200
-          ]
+          "args": [200]
         }
       }
     };
@@ -114,8 +115,8 @@ describe('embark.Contracts', function() {
     let embarkObj = {
       registerAPICall: () => {},
       fs: {
-        existsSync: () => { return false },
-        dappPath: () => { return "ok" }
+        existsSync: () => { return false; },
+        dappPath: () => { return "ok"; }
       },
       logger: new Logger({}),
       events: events
@@ -234,14 +235,10 @@ describe('embark.Contracts', function() {
         },
         "MySimpleStorage": {
           "instanceOf": "SimpleStorage",
-          "args": [
-            300
-          ]
+          "args": [300]
         },
         "SimpleStorage": {
-          "args": [
-            200
-          ]
+          "args": [200]
         },
         "AnotherSimpleStorage": {
           "instanceOf": "SimpleStorage"
@@ -252,8 +249,8 @@ describe('embark.Contracts', function() {
     let embarkObj = {
       registerAPICall: () => {},
       fs: {
-        existsSync: () => { return false },
-        dappPath: () => { return "ok" }
+        existsSync: () => { return false; },
+        dappPath: () => { return "ok"; }
       },
       logger: new Logger({}),
       events: events

--- a/packages/embark/src/test/modules/compiler/compiler.js
+++ b/packages/embark/src/test/modules/compiler/compiler.js
@@ -1,6 +1,7 @@
 /*global describe, it, require*/
 import { Events, Plugins, TestLogger } from 'embark-core';
 import { File, Types } from "embark-utils";
+import findUp from 'find-up';
 
 const assert = require('assert');
 
@@ -10,7 +11,11 @@ const readFile = function(file) {
   return new File({filename: file, type: Types.dappFile, path: file});
 };
 
-const currentSolcVersion = require('../../../../package.json').dependencies.solc;
+// will need refactor if we some day switch back to specifying version ranges
+const currentSolcVersion = require(findUp.sync(
+  'node_modules/embark-solidity/package.json',
+  {cwd: __dirname}
+)).dependencies.solc;
 const TestEvents = {
   request: (cmd, cb) => {
     cb(currentSolcVersion);

--- a/packages/embark/src/test/modules/solidity/contracts/simple_storage.sol
+++ b/packages/embark/src/test/modules/solidity/contracts/simple_storage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 contract SimpleStorage {
   uint public storedData;
@@ -16,4 +16,3 @@ contract SimpleStorage {
   }
 
 }
-

--- a/packages/embark/src/test/modules/solidity/contracts/token.sol
+++ b/packages/embark/src/test/modules/solidity/contracts/token.sol
@@ -1,6 +1,6 @@
 // https://github.com/nexusdev/erc20/blob/master/contracts/base.sol
 
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 contract Token {
 

--- a/packages/embark/src/test/modules/solidity/solidity.js
+++ b/packages/embark/src/test/modules/solidity/solidity.js
@@ -8,11 +8,11 @@ let readFile = function(file) {
 };
 
 let ipcObject = new IPC({
-  ipcRole: 'none',
+  ipcRole: 'none'
 });
 
 let generateApiObject = function() {
-  var solcVersion = "0.5.0";
+  var solcVersion = "0.6.1";
 
   var TestEvents = {
     request: (cmd, cb) => {

--- a/packages/embark/src/test/vm_fs.js
+++ b/packages/embark/src/test/vm_fs.js
@@ -6,7 +6,7 @@ const os = require('os');
 const path = require('path');
 const underlyingFs = require('fs-extra');
 
-describe('fs', () => {
+describe('embark.vm fs', () => {
   let fsMethods = {};
   let oldConsoleError;
   let oldDappPath;

--- a/packages/plugins/scaffolding/src/contractLanguage/solidityBuilder/templates/contract.sol.hbs
+++ b/packages/plugins/scaffolding/src/contractLanguage/solidityBuilder/templates/contract.sol.hbs
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 {{#each associations}}
 import "./{{@key}}.sol";
@@ -48,12 +48,13 @@ contract {{contractName}} {
     }
 
     function add({{#each attributes}}{{this}}{{#ifstring this}} memory{{/ifstring}} _{{@key}}{{#unless @last}}, {{/unless}}{{/each}}) public {
-        uint id = items.length++;
-        items[id] = {{structName}}({
+        uint id = items.length;
+
+        items.push({{structName}}({
         {{#each attributes}}
             {{@key}}: _{{@key}}{{#unless @last}},{{/unless}}
         {{/each}}
-        });
+        }));
 
         {{#each associations}}
         {{#ifeq this 'hasMany'}}

--- a/packages/plugins/solidity/package.json
+++ b/packages/plugins/solidity/package.json
@@ -50,9 +50,10 @@
     "embark-core": "^5.1.0-nightly.4",
     "embark-i18n": "^5.1.0-nightly.1",
     "embark-utils": "^5.1.0-nightly.4",
+    "find-up": "4.1.0",
     "fs-extra": "8.1.0",
     "semver": "5.6.0",
-    "solc": "0.5.0",
+    "solc": "0.6.1",
     "uuid": "3.3.2"
   },
   "devDependencies": {

--- a/packages/plugins/solidity/src/solcP.js
+++ b/packages/plugins/solidity/src/solcP.js
@@ -21,7 +21,10 @@ class SolcProcess extends ProcessWrapper {
     // TODO: only available in 0.4.11; need to make versions warn about this
     try {
       let func = this.solc.compileStandardWrapper;
-      if (semver.gte(this.solc.version(), '0.5.0')) {
+      const solcVersion = this.solc.version();
+      if (semver.gte(solcVersion, '0.6.0')) {
+        func = (json, importCb) => this.solc.compile(json, {import: importCb});
+      } else if (semver.gte(solcVersion, '0.5.0')) {
         func = this.solc.compile;
       }
       let output = func(JSON.stringify(jsonObj), this.findImports.bind(this));

--- a/packages/plugins/solidity/src/solcW.js
+++ b/packages/plugins/solidity/src/solcW.js
@@ -1,6 +1,7 @@
 import { __ } from 'embark-i18n';
 import { ProcessLauncher } from 'embark-core';
 import { dappPath, joinPath, toForwardSlashes } from 'embark-utils';
+import findUp from "find-up";
 const semver = require('semver');
 const uuid = require('uuid/v1');
 
@@ -78,7 +79,8 @@ class SolcW {
             'problems running on Windows with Node.js v12.x and newer.'
           ].join(' '));
         }
-        if (solcVersion === this.embark.config.package.dependencies.solc) {
+        // will need refactor if we some day switch back to specifying version ranges
+        if (solcVersion === require(findUp.sync('package.json', {cwd: __dirname})).dependencies.solc) {
           return this.solcProcess.send({action: 'loadCompiler', requirePath: 'solc'});
         }
         this.events.request("version:getPackageLocation", "solc", solcVersion, (err, location) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19403,19 +19403,7 @@ socks@~2.3.2:
     ip "^1.1.5"
     smart-buffer "4.0.2"
 
-solc@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.0.tgz#2deb2ae992acac3afb909f85c38d00f01dcb335e"
-  integrity sha512-mdLHDl9WeYrN+FIKcMc9PlPfnA9DG9ur5QpCDKcv6VC4RINAsTF4EMuXMZMKoQTvZhtLyJIVH/BZ+KU830Z8Xg==
-  dependencies:
-    fs-extra "^0.30.0"
-    keccak "^1.0.2"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    yargs "^11.0.0"
-
-solc@^0.6.0:
+solc@0.6.1, solc@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.6.1.tgz#9a5080dd4106e37a87f84e6b355d4478e1ea5832"
   integrity sha512-iKqNYps2p++x8L9sBg7JeAJb7EmW8VJ/2asAzwlLYcUhj86AzuWLe94UTSQHv1SSCCj/x6lya8twvXkZtlTbIQ==
@@ -22181,7 +22169,7 @@ yargs-unparser@1.6.0:
     lodash "^4.17.15"
     yargs "^13.3.0"
 
-yargs@11.1.0, yargs@^11.0.0:
+yargs@11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==


### PR DESCRIPTION
### What did you refactor, implement, or fix?

Bumped the bundled [solc](https://www.npmjs.com/package/solc) to version `0.6.1`. This PR builds on the dependabot commit in #2189 (which has been closed; this one replaces it).

#### How did you do it?

Make various related changes to templates, tests, etc. The methodology for finding files that needed changes was to search through the whole monorepo for the strings "solc" and "solidity" and then inspect the hits to see whether changes were needed/appropriate.

Remove `solc` as a dependency in `packages/embark/package.json` so that it's only a proper dependency in `packages/plugins/solidity/package.json`. Adjust how the "bundled" `solc` package's version is determined, i.e. inspect the `package.json` of `embark-solidity` instead of `embark`.

When `solc`'s version is `>=0.6.0` use the [new callback API][api].

[api]: https://github.com/ethereum/solc-js/blob/master/README.md#example-usage-with-import-callback

### Questions

Should the commit be reworded as `feat(@embark/solidity): ...` so that it shows up in the CHANGELOG as a new feature?  I'm not sure if that's needed or desirable, but am open to suggestions.

### Cool Spaceship Picture

![](https://www.this-is-cool.co.uk/wp-content/uploads/2018/12/the-scifi-art-of-colie-wertz-21.jpg)