### PR TITLE
ci: adjust Nightlies/release job so NPM credentials are always removed

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -75,6 +75,7 @@ jobs:
           # EMBARKBOT_NPM_TOKEN should correspond to https://www.npmjs.com/~embarkbot
           NPM_TOKEN: ${{ secrets.EMBARKBOT_NPM_TOKEN }}
       - name: Remove NPM credentials
+        if: always()
         # Delete .npmrc instead of running `npm logout` because the logout command permanently invalidates the current token
         run: |
-          rm ${HOME}/.npmrc
+          rm -f ${HOME}/.npmrc


### PR DESCRIPTION
That is, the file `${HOME}/.npmrc` will be deleted by the "Remove NPM credentials" step even if a previous step failed.

---

I noticed that step didn't run when *Nightlies/release* recently failed, but it's a good idea for it to always run.