### PR TITLE
build(deps): bump ganache-cli from 6.7.0 to 6.8.2

### DIFF
--- a/dapps/tests/contracts/test/simple_storage_spec.js
+++ b/dapps/tests/contracts/test/simple_storage_spec.js
@@ -13,14 +13,13 @@ config({
 });
 
 contract("SimpleStorage", function () {
-  this.timeout(0);
-
   it("should set constructor value", async function () {
     let result = await SimpleStorage.methods.storedData().call();
     assert.strictEqual(parseInt(result, 10), 100);
   });
 
   it("set storage value", async function () {
+    this.timeout(0);
     const toSend = SimpleStorage.methods.set(150);
     const gas = await toSend.estimateGas();
     await toSend.send({gas});

--- a/packages/embark/package.json
+++ b/packages/embark/package.json
@@ -90,7 +90,7 @@
     "find-up": "2.1.0",
     "flatted": "0.2.3",
     "fs-extra": "8.1.0",
-    "ganache-cli": "6.7.0",
+    "ganache-cli": "6.8.2",
     "glob": "7.1.4",
     "globule": "1.2.1",
     "hosted-git-info": "2.7.1",

--- a/packages/plugins/ganache/package.json
+++ b/packages/plugins/ganache/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.7.4",
     "core-js": "3.4.3",
-    "ganache-cli": "6.7.0"
+    "ganache-cli": "6.8.2"
   },
   "devDependencies": {
     "embark-solo": "^5.1.0-nightly.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10383,10 +10383,10 @@ fuzzy@0.1.3:
   resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
   integrity sha1-THbsL/CsGjap3M+aAN+GIweNTtg=
 
-ganache-cli@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.7.0.tgz#b59845578221bdf686cf124d007c5ee62e85a62f"
-  integrity sha512-9CZsClo9hl5MxGL7hkk14mie89Q94P0idh92jcV7LmppTYTCG7SHatuwcfqN7emFHArMt3fneN4QbH2do2N6Ow==
+ganache-cli@6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.8.2.tgz#357b5ea93f013a7f0fce4ede1b8bec8613e95dd3"
+  integrity sha512-FgsJx/hHh7A1/fmSQpNT5jxZ3dYEal4zQMqYyA8Bm7S6MgrVO48hIjnROn2JteubHY8Rob8LzxMkhEvoQce7WA==
   dependencies:
     ethereumjs-util "6.1.0"
     source-map-support "0.5.12"


### PR DESCRIPTION
### What did you refactor, implement, or fix?

Bumped `ganache-cli` from version `6.7.0` to `6.8.2`.

Also, in `dapps/tests/contracts` move the `this.timeout(0);` inside the `it(...)` for the expensive gas esimation (involving `SimpleStorage.methods.set`) because it otherwise doesn't seem to have an effect on the default 15 second timeout.

### Review

@richard-ramos this one's for you!

### Cool Spaceship Picture

![](https://sen.com/thumbs/1024x576/img/26f84e88ea244ad59f1d51e70b8e0a46.jpg)

---

Before committing, I checked the test dapps work and that `embark run` works in a fresh `embark_demo` with `embark simulator` running in another terminal.