### PR TITLE
refactor(@embark/transaction-logger): change log storage and read

### DIFF
--- a/packages/cockpit/ui/src/actions/index.js
+++ b/packages/cockpit/ui/src/actions/index.js
@@ -173,7 +173,7 @@ export const processLogs = {
 export const CONTRACT_LOGS = createRequestTypes('CONTRACT_LOGS');
 export const contractLogs = {
   request: () => action(CONTRACT_LOGS[REQUEST]),
-  success: (contractLogs) => action(CONTRACT_LOGS[SUCCESS], {contractLogs}),
+  success: (contractLogs) => action(CONTRACT_LOGS[SUCCESS], {contractLogs: contractLogs ? contractLogs.reverse() : []}),
   failure: (error) => action(CONTRACT_LOGS[FAILURE], {error, name: 'contractLogs'})
 };
 


### PR DESCRIPTION
### What did you refactor, implement, or fix?

Changes the way the logs are stored to straight up be logged as an array and then reads it as such
 It also removes the reverse from the read and puts it in the UI instead since it's the UI that needs it reversed.

#### Is there anything that needs special attention (breaking changes, etc)?

Once merged, this needs the old log file to be deleted from `.embark`, since the structure is different. (`embark reset` does the job)

### Cool Spaceship Picture
 
🚀 
