### PR TITLE
fix(@embark/test): fix Teller tests by introducing bigger gas limit

### DIFF
--- a/packages/plugins/ethereum-blockchain-client/src/index.js
+++ b/packages/plugins/ethereum-blockchain-client/src/index.js
@@ -70,8 +70,7 @@ class EthereumBlockchainClient {
       }
 
       if (!contract.gasPrice) {
-        const gasPrice = await web3.eth.getGasPrice();
-        contract.gasPrice = contract.gasPrice || gasPrice;
+        contract.gasPrice = await web3.eth.getGasPrice();
       }
 
       embarkJsUtils.secureSend(web3, contractObject, {

--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -2,7 +2,9 @@ class Ganache {
   constructor(embark) {
     embark.events.request('blockchain:vm:register', () => {
       const ganache = require('ganache-cli');
-      return ganache.provider();
+      // Default to 8000000, which is the server default
+      // Somehow, the provider default is 6721975
+      return ganache.provider({gasLimit: '0x7A1200'});
     });
   }
 }

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -7,7 +7,7 @@ const Web3 = require('web3');
 
 const Reporter = require('./reporter');
 
-const GAS_LIMIT = 6000000;
+const GAS_LIMIT = 8000000;
 const JAVASCRIPT_TEST_MATCH = /^.+\.js$/i;
 const TEST_TIMEOUT = 15000; // 15 seconds in milliseconds
 


### PR DESCRIPTION
### What did you refactor, implement, or fix?

Teller tests used to fail because of "Out of gas exception". 

#### How did you do it?

I put the default gas limit to `8000000` in the provider and in the contracts, so they match the Ganache server default. This way, all tests pass, including the test app (nothing changed)


### Questions

We should really implement a way to change that gas limit either per test or for all tests. Should it be the gas limit config in contracts config? Will do it in another PR once we take a decision.

### Cool Spaceship Picture

![Star-Wars-on-Earth-Over-Manhattan](https://user-images.githubusercontent.com/11926403/72819130-ad362d00-3c3a-11ea-9d86-53b59bb044ab.png)

