### PR TITLE
fix(@embark/proxy): Parse `rpcPort` from config as integer

### DIFF
--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -92,10 +92,15 @@ export default class ProxyManager {
       return;
     }
     this.inited = true;
-
-    let port = this.embark.config.blockchainConfig.rpcPort;
-    if (!port && port !== 0) {
-      port = 8545;
+    const rpcConfigPort = this.embark.config.blockchainConfig.rpcPort;
+    let port: number = 0;
+    try {
+      port = typeof rpcConfigPort === "string" ? parseInt(rpcConfigPort, 10) : rpcConfigPort;
+      if (!port && port !== 0) {
+        port = 8545;
+      }
+    } catch (err) {
+      this.logger.error(`Blockchain config 'rpcPort' contains an invalid value: '${rpcConfigPort}'`);
     }
 
     // setup ports


### PR DESCRIPTION
## User reported error
i recently updated to embark 5.0 im having issues connecting to a local node each time i connect to it i get the following output from the embark console

```
Error during proxy setup: Port should be >= 0 and < 65536. Received 754510.. Use '--loglevel debug' for more detailed information.
```

This is what i have under the blockchain.js  file
```
localDev: {
    endpoint: "http://127.0.0.1:7545",
    accounts: [{
      nodeAccounts: true,
    }]
  }
```
### Problem
The port to start the proxy on is incremented by a constant value (using the `+` operator), however the port comes from the config and in the case where it is a string, the `+` operator acts as a string concatentation.

### Fix
Ensure the port from the config is always parsed to a number before attempting to add the constant proxy port offset.

### Cool Spaceship Picture
![Cool spaceship picture](https://4.bp.blogspot.com/-E7GDcW19Ago/TxtBYdBGOHI/AAAAAAAAinQ/9TldKBRGG5E/s1600/05.jpg)
