### PR TITLE
fix(@embark/embarkjs): change enableEthereum to not rely on returned accounts array

### DIFF
--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -208,17 +208,23 @@ Blockchain.doConnect = function(connectionList, opts, doneCb) {
   });
 };
 
-Blockchain.enableEthereum = function() {
-  if (typeof window !== 'undefined' && window.ethereum) {
-    return ethereum.enable().then((accounts) => {
-      this.blockchainConnector.setProvider(ethereum);
-      this.blockchainConnector.setDefaultAccount(accounts[0]);
-      contracts.forEach(contract => {
-        contract.options.from = this.blockchainConnector.getDefaultAccount();
-      });
-      return accounts;
-    });
+// See https://eips.ethereum.org/EIPS/eip-1102
+Blockchain.enableEthereum = async function() {
+  if (typeof window === 'undefined' || !window.ethereum) {
+    throw new Error('ethereum not available in this browser');
   }
+
+  await ethereum.enable();
+  this.blockchainConnector.setProvider(ethereum);
+
+  const accounts = await this.blockchainConnector.getAccounts();
+  this.blockchainConnector.setDefaultAccount(accounts[0]);
+
+  contracts.forEach(contract => {
+    contract.options.from = this.blockchainConnector.getDefaultAccount();
+  });
+
+  return accounts;
 };
 
 Blockchain.execWhenReady = function(cb) {


### PR DESCRIPTION
Some ethereum providers (e.g. Opera implementation) do not return the accounts array in the `enable` call.

### What did you refactor, implement, or fix?

Fixed initialization errors on Ethereum-enabled DOM environments that do not return an array of accounts in the `enable` method.

#### How did you do it?

Modified `Blockchain.enableEthereum` to get the accounts explicitly after a successful `ethereum.enable` call, keeping the promises chain.

