### PR TITLE
fix: set helper methods on contracts

### DIFF
--- a/dapps/tests/app/test/simple_storage_deploy_spec.js
+++ b/dapps/tests/app/test/simple_storage_deploy_spec.js
@@ -4,19 +4,8 @@ const {Utils} = require('Embark/EmbarkJS');
 
 contract("SimpleStorage Deploy", function () {
   let simpleStorageInstance;
-  before(function() {
-    return new Promise(async (resolve, reject) => {
-      const gas = await SimpleStorage.deploy({arguments: [150]}).estimateGas();
-
-      Utils.secureSend(web3, SimpleStorage.deploy({arguments: [150]}), {gas, from: web3.eth.defaultAccount}, true, function(err, receipt) {
-        if(err) {
-          return reject(err);
-        }
-        simpleStorageInstance = SimpleStorage;
-        simpleStorageInstance.options.address = receipt.contractAddress;
-        resolve();
-      });
-    });
+  before(async () => {
+    simpleStorageInstance = await SimpleStorage.deploy([150]);
   });
 
   it("should set constructor value", async function () {

--- a/packages/embarkjs/embarkjs/src/lib/utils.js
+++ b/packages/embarkjs/embarkjs/src/lib/utils.js
@@ -3,6 +3,12 @@
 const Web3 = global.Web3 || require('web3');
 
 let Utils = {
+  hexPrefix: function(str) {
+    if (!(str && str.match)) return;
+    if (str.match(/^0x/)) return str;
+
+    return `0x${str}`;
+  },
   fromAscii: function(str) {
     var _web3 = new Web3();
     return _web3.utils ? _web3.utils.fromAscii(str) : _web3.fromAscii(str);

--- a/packages/embarkjs/web3/src/index.js
+++ b/packages/embarkjs/web3/src/index.js
@@ -48,11 +48,12 @@ __embarkWeb3.newContract = function (options) {
 };
 
 __embarkWeb3.send = function () {
+  console.log('ARGUEMTNS', ...arguments);
   return this.web3.eth.sendTransaction(...arguments);
 };
 
 __embarkWeb3.toWei = function () {
-  return this.web3.toWei(...arguments);
+  return this.web3.utils.toWei(...arguments);
 };
 
 __embarkWeb3.getNetworkId = function () {

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -131,6 +131,7 @@ class MochaTestRunner {
                 compiledContracts[contract.className] = {};
               }
               instance.options.from = accounts[0];
+              instance.options.code = contract.code;
               instance.options.gas = GAS_LIMIT;
               Object.setPrototypeOf(compiledContracts[contract.className], instance);
             }


### PR DESCRIPTION
Set these up so we can call `deploy`, `at`, and `new` on contract
classes.

### What did you refactor, implement, or fix?

This PR cherry-picks https://github.com/embarklabs/embark/pull/1670/commits/3f6442f3043d52cd3cecea6311f55aa7037939cb and https://github.com/embarklabs/embark/pull/1670/commits/fec1babc9fc19e8d706455ca447f8173f8698149 as they didn't make it into `master` back then, right before the v4 release.

#### How did you do it?

<!-- Provide a summary of the improvement/s you are submitting. -->

#### Is there anything that needs special attention (breaking changes, etc)?

<!-- Explain any special considerations. -->

### Questions

<!-- If relevant, write a list of questions that you would like to discuss related to your changes. -->

### Review

<!-- Use @mentions for quick questions, specific feedback, and progress updates. -->

### Cool Spaceship Picture

<!-- Star Trek/Wars, n/BSG, Voltron, Transformers... all welcome, but not all equally cool ;-) ->
