### PR TITLE
update the footer

### DIFF
--- a/site/themes/embark/layout/partial/footer.swig
+++ b/site/themes/embark/layout/partial/footer.swig
@@ -68,9 +68,11 @@
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://status.im/" target="_blank">Status</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://keycard.tech/" target="_blank">Keycard</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://dap.ps/" target="_blank">dap.ps</a></li>
-            <li class="o-list-bare__item"><a class="u-link-ghost" href="https://embark.status.im/" target="_blank">Embark</a></li>
+            <li class="o-list-bare__item"><a class="u-link-ghost" href="https://teller.exchange/" target="_blank">Teller</a></li>
+            <li class="o-list-bare__item"><a class="u-link-ghost" href="https://assemble.fund/" target="_blank">Assemble</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://subspace.status.im/" target="_blank">Subspace</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://vac.dev/" target="_blank">Vac</a></li>
+            <li class="o-list-bare__item"><a class="u-link-ghost" href="https://nimbus.team/" target="_blank">Nimbus</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
- Add Teller, Assemble and Nimbus
- Remove Embark which is a duplicate of the current website (It is the same as other the Status Network websites, e.g., https://dev.status.im/)

<img width="293" alt="Screen Shot 2020-01-24 at 1 33 07 AM" src="https://user-images.githubusercontent.com/41753422/73004089-13dd6580-3e4a-11ea-9343-9ee1b0529c1e.png">

The order of the Status Network projects is

Products
Dev Tools
Infra
(Suggested by Jonny)