### PR TITLE
ci: revise "ci:full" script to run some steps collectively

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:no-ui": "npm run build -- --ignore embark-ui",
     "ci": "node scripts/monorun --ignore embark-dapp-* --stream ci",
     "ci:dapps": "lerna run --concurrency=1 --scope embark-dapp-* --stream ci",
-    "ci:full": "npm-run-all cwtree \"ci -- --concurrency={1}\" ci:dapps cwtree -- 1",
+    "ci:full": "npm-run-all cwtree typecheck \"lint -- --concurrency={1}\" build:no-ui \"test -- --concurrency={1}\" ci:dapps cwtree -- 1",
     "clean": "node scripts/monorun --stream clean",
     "clean:full": "npx npm-run-all clean clean:top",
     "clean:top": "npm run reset:top && npx rimraf node_modules",


### PR DESCRIPTION
This results in faster completions on Azure Pipelines. For an individual build (OS/Node.js combination) it shaves off ~10 or more minutes, depending on the OS.

Once the `lint` and `test` steps have collective implementations we should be able to shave another couple of minutes off of the completion times.

The steps that take the longest are `yarn install` (~4 minutes), collective `typecheck` (~4 minutes), and `ci:dapps` (~3 minutes).