### PR TITLE
feat(@embark/test-runner): introduce artifacts.require API

### DIFF
--- a/dapps/templates/boilerplate/test/contract_spec.js
+++ b/dapps/templates/boilerplate/test/contract_spec.js
@@ -1,6 +1,6 @@
-/*global contract, it*/
+/*global artifacts, contract, it*/
 /*
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 
 let accounts;
 

--- a/dapps/templates/demo/test/simple_storage_spec.js
+++ b/dapps/templates/demo/test/simple_storage_spec.js
@@ -1,5 +1,5 @@
-/*global contract, config, it, assert, web3*/
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+/*global artifacts, contract, config, it, assert, web3*/
+const SimpleStorage = artifacts.require('SimpleStorage');
 
 let accounts;
 

--- a/dapps/templates/simple/test/contract_spec.js
+++ b/dapps/templates/simple/test/contract_spec.js
@@ -1,6 +1,6 @@
-/*global contract, it*/
+/*global artifacts, contract, it*/
 /*
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 
 let accounts;
 

--- a/dapps/tests/app/test/another_storage_spec.js
+++ b/dapps/tests/app/test/another_storage_spec.js
@@ -1,7 +1,7 @@
-/*global contract, config, it, web3*/
+/*global artifacts, contract, config, it, web3*/
 const assert = require('assert');
-const AnotherStorage = require('Embark/contracts/AnotherStorage');
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const AnotherStorage = artifacts.require('AnotherStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 
 let accounts, defaultAccount;
 const numAddresses = 10;

--- a/dapps/tests/app/test/array_references_spec.js
+++ b/dapps/tests/app/test/array_references_spec.js
@@ -1,7 +1,7 @@
-/*global contract, config, it, web3*/
+/*global artifacts, contract, config, it, web3*/
 const assert = require('assert');
-const SomeContract = require('Embark/contracts/SomeContract');
-const MyToken2 = require('Embark/contracts/MyToken2');
+const SomeContract = artifacts.require('SomeContract');
+const MyToken2 = artifacts.require('MyToken2');
 
 config({
   contracts: {
@@ -38,4 +38,3 @@ contract("SomeContract", function() {
   });
 
 });
-

--- a/dapps/tests/app/test/embarkJS_spec.js
+++ b/dapps/tests/app/test/embarkJS_spec.js
@@ -1,7 +1,7 @@
-/*global describe, it, web3, config*/
+/*global artifacts, describe, it, web3, config*/
 const assert = require('assert');
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
-const EmbarkJS = require('Embark/EmbarkJS');
+const SimpleStorage = artifacts.require('SimpleStorage');
+const EmbarkJS = artifacts.require('EmbarkJS');
 
 config({
   namesystem: {
@@ -58,4 +58,3 @@ describe("EmbarkJS functions", function() {
     assert.strictEqual(parseInt(result, 10), 100);
   });
 });
-

--- a/dapps/tests/app/test/expiration_spec.js
+++ b/dapps/tests/app/test/expiration_spec.js
@@ -1,5 +1,5 @@
-/*global contract, config, it, assert, mineAtTimestamp*/
-const Expiration = require('Embark/contracts/Expiration');
+/*global artifacts, contract, config, it, assert, mineAtTimestamp*/
+const Expiration = artifacts.require('Expiration');
 const now = Math.floor(new Date().getTime()/1000.0); // Get unix epoch. The getTime method returns the time in milliseconds.
 
 config({

--- a/dapps/tests/app/test/interface_spec.js
+++ b/dapps/tests/app/test/interface_spec.js
@@ -1,6 +1,6 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const AnotherStorage = require('Embark/contracts/AnotherStorage');
+const AnotherStorage = artifacts.require('AnotherStorage');
 
 // FIXME this doesn't work and no idea how it ever worked because ERC20 is not defined anywhere
 // config({
@@ -22,4 +22,3 @@ contract("AnotherStorageWithInterface", function() {
     assert.strictEqual(result.toString(), '0x0000000000000000000000000000000000000000');
   });
 });
-

--- a/dapps/tests/app/test/lib_test_spec.js
+++ b/dapps/tests/app/test/lib_test_spec.js
@@ -1,6 +1,6 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const Test2 = require('Embark/contracts/Test2');
+const Test2 = artifacts.require('Test2');
 
 config({
   contracts: {

--- a/dapps/tests/app/test/namesystem_spec.js
+++ b/dapps/tests/app/test/namesystem_spec.js
@@ -1,8 +1,8 @@
-/*global describe, it, config*/
+/*global artifacts, describe, it, config*/
 const assert = require('assert');
-const MyToken = require('Embark/contracts/MyToken');
-const MyToken2 = require('Embark/contracts/MyToken2');
-const EmbarkJS = require('Embark/EmbarkJS');
+const MyToken = artifacts.require('MyToken');
+const MyToken2 = artifacts.require('MyToken2');
+const EmbarkJS = artifacts.require('EmbarkJS');
 
 let accounts;
 
@@ -55,4 +55,3 @@ describe("ENS functions", function() {
     assert.strictEqual(myToken2Name, 'MyToken2.embark.eth');
   });
 });
-

--- a/dapps/tests/app/test/plugin_storage_spec.js
+++ b/dapps/tests/app/test/plugin_storage_spec.js
@@ -1,7 +1,7 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const PluginStorage = require('Embark/contracts/PluginStorage');
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const PluginStorage = artifacts.require('PluginStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 
 config({
   contracts: {

--- a/dapps/tests/app/test/simple_storage_deploy_spec.js
+++ b/dapps/tests/app/test/simple_storage_deploy_spec.js
@@ -1,6 +1,6 @@
-/*global contract, it, assert, before, web3*/
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
-const {Utils} = require('Embark/EmbarkJS');
+/*global artifacts, contract, it, assert, before, web3*/
+const SimpleStorage = artifacts.require('SimpleStorage');
+const {Utils} = artifacts.require('EmbarkJS');
 
 contract("SimpleStorage Deploy", function () {
   let simpleStorageInstance;

--- a/dapps/tests/app/test/simple_storage_spec.js
+++ b/dapps/tests/app/test/simple_storage_spec.js
@@ -1,7 +1,7 @@
 /*global contract, config, it, assert, web3*/
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 let accounts;
-const {Utils} = require('Embark/EmbarkJS');
+const {Utils} = artifacts.require('EmbarkJS');
 
 config({
   contracts: {

--- a/dapps/tests/app/test/token_spec.js
+++ b/dapps/tests/app/test/token_spec.js
@@ -1,11 +1,11 @@
-/*global describe, config, it, web3*/
+/*global artifacts, describe, config, it, web3*/
 const assert = require('assert');
-const Token = require('Embark/contracts/Token');
-const MyToken = require('Embark/contracts/MyToken');
-const MyToken2 = require('Embark/contracts/MyToken2');
-const AlreadyDeployedToken = require('Embark/contracts/AlreadyDeployedToken');
-const Test = require('Embark/contracts/Test');
-const SomeContract = require('Embark/contracts/SomeContract');
+const Token = artifacts.require('Token');
+const MyToken = artifacts.require('MyToken');
+const MyToken2 = artifacts.require('MyToken2');
+const AlreadyDeployedToken = artifacts.require('AlreadyDeployedToken');
+const Test = artifacts.require('Test');
+const SomeContract = artifacts.require('SomeContract');
 
 config({
   namesystem: {

--- a/dapps/tests/contracts/test/another_storage_spec.js
+++ b/dapps/tests/contracts/test/another_storage_spec.js
@@ -1,7 +1,7 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const AnotherStorage = require('Embark/contracts/AnotherStorage');
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const AnotherStorage = artifacts.require('AnotherStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 let accounts;
 
 config({

--- a/dapps/tests/contracts/test/array_references_spec.js
+++ b/dapps/tests/contracts/test/array_references_spec.js
@@ -1,8 +1,8 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const SomeContract = require('Embark/contracts/SomeContract');
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
-const MyToken2 = require('Embark/contracts/MyToken2');
+const SomeContract = artifacts.require('SomeContract');
+const SimpleStorage = artifacts.require('SimpleStorage');
+const MyToken2 = artifacts.require('MyToken2');
 
 config({
   contracts: {
@@ -42,4 +42,3 @@ contract("SomeContract", function() {
   });
 
 });
-

--- a/dapps/tests/contracts/test/lib_test_spec.js
+++ b/dapps/tests/contracts/test/lib_test_spec.js
@@ -1,6 +1,6 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const Test2 = require('Embark/contracts/Test2');
+const Test2 = artifacts.require('Test2');
 
 config({
   contracts: {

--- a/dapps/tests/contracts/test/simple_storage_spec.js
+++ b/dapps/tests/contracts/test/simple_storage_spec.js
@@ -1,6 +1,6 @@
-/*global contract, config, it*/
+/*global artifacts, contract, config, it*/
 const assert = require('assert');
-const SimpleStorage = require('Embark/contracts/SimpleStorage');
+const SimpleStorage = artifacts.require('SimpleStorage');
 
 config({
   contracts: {

--- a/dapps/tests/contracts/test/token_spec.js
+++ b/dapps/tests/contracts/test/token_spec.js
@@ -1,10 +1,10 @@
-/*global describe, config, it*/
+/*global artifacts, describe, config, it*/
 const assert = require('assert');
-const Token = require('Embark/contracts/Token');
-const MyToken = require('Embark/contracts/MyToken');
-const MyToken2 = require('Embark/contracts/MyToken2');
-const AlreadyDeployedToken = require('Embark/contracts/AlreadyDeployedToken');
-const Test = require('Embark/contracts/Test');
+const Token = artifacts.require('Token');
+const MyToken = artifacts.require('MyToken');
+const MyToken2 = artifacts.require('MyToken2');
+const AlreadyDeployedToken = artifacts.require('AlreadyDeployedToken');
+const Test = artifacts.require('Test');
 
 config({
   contracts: {

--- a/packages/plugins/mocha-tests/package.json
+++ b/packages/plugins/mocha-tests/package.json
@@ -50,6 +50,7 @@
     "@babel/runtime-corejs3": "7.7.4",
     "@types/async": "3.0.3",
     "async": "3.1.0",
+    "colors": "1.4.0",
     "core-js": "3.4.3",
     "embark-i18n": "^5.1.1",
     "embark-utils": "^5.2.0-nightly.1",

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -1,3 +1,4 @@
+import 'colors';
 import {__} from 'embark-i18n';
 
 const async = require('async');
@@ -31,6 +32,31 @@ class MochaTestRunner {
     );
   }
 
+  static originalRequire = require('module').prototype.require;
+
+  static requireArtifact(artifactName, compiledContracts) {
+    if (artifactName === 'EmbarkJS') return EmbarkJS;
+
+    const instance = compiledContracts[artifactName];
+
+    if (!instance) {
+      compiledContracts[artifactName] = {};
+    }
+
+    if (!compiledContracts[artifactName].abiDefinition) {
+      return compiledContracts[artifactName];
+    }
+
+    try {
+      return Object.setPrototypeOf(
+        instance,
+        EmbarkJS.Blockchain.Contract(instance)
+      );
+    } catch (e) {
+      return instance;
+    }
+  }
+
   addFile(path) {
     if (!this.match(path)) {
       throw new Error(`invalid JavaScript test path: ${path}`);
@@ -49,7 +75,6 @@ class MochaTestRunner {
     this.options = options;
 
     const Module = require("module");
-    const originalRequire = require("module").prototype.require;
 
     let accounts = [];
     let compiledContracts = {};
@@ -185,29 +210,29 @@ class MochaTestRunner {
                 return seriesCb(null, 0);
               }
 
+              let testRunner = this;
+
               Module.prototype.require = function(req) {
+                if (["Embark/EmbarkJS", "EmbarkJS"].includes(req)) {
+                  testRunner.logger.warn(
+                    `${__('WARNING!')} ${__('Use')} ${`artifacts.require('EmbarkJS')`.cyan}, ${__('the syntax').yellow} ${`require('${req}')`.cyan} ${__('has been deprecated and will be removed in future versions').yellow}`
+                  );
+                  return MochaTestRunner.requireArtifact("EmbarkJS");
+                }
+
                 const prefix = "Embark/contracts/";
                 if (req.startsWith(prefix)) {
-                  const contractClass = req.replace(prefix, "");
-                  const instance = compiledContracts[contractClass];
-
-                  if (!instance) {
-                    compiledContracts[contractClass] = {};
-                  }
-                  if (!compiledContracts[contractClass].abiDefinition) {
-                    return compiledContracts[contractClass];
-                  }
-                  try {
-                    return Object.setPrototypeOf(instance, EmbarkJS.Blockchain.Contract(instance));
-                  } catch (e) {
-                    return instance;
-                  }
-                }
-                if (req === "Embark/EmbarkJS") {
-                  return EmbarkJS;
+                  const artifactName = req.replace(prefix, "");
+                  testRunner.logger.warn(
+                    `${__('WARNING!')} ${__('Use')} ${`artifacts.require('${artifactName}')`.cyan}, ${__('the syntax').yellow} ${`require('${req}')`.cyan} ${__('has been deprecated and will be removed in future versions').yellow}`
+                  );
+                  return MochaTestRunner.requireArtifact(
+                    artifactName,
+                    compiledContracts
+                  );
                 }
 
-                return originalRequire.apply(this, arguments);
+                return MochaTestRunner.originalRequire.call(this, req);
               };
 
               const mocha = new Mocha();
@@ -222,11 +247,18 @@ class MochaTestRunner {
                 global.config = config;
               });
 
+              global.artifacts = {
+                require: (artifactName) => MochaTestRunner.requireArtifact(
+                  artifactName,
+                  compiledContracts
+                )
+              };
+
               mocha.suite.timeout(TEST_TIMEOUT);
               mocha.addFile(file);
 
               mocha.run((failures) => {
-                Module.prototype.require = originalRequire;
+                Module.prototype.require = MochaTestRunner.originalRequire;
                 seriesCb(null, failures);
               });
             });
@@ -237,7 +269,7 @@ class MochaTestRunner {
       }
     ], (err) => {
       this.embark.config.plugins.runActionsForEvent('tests:finished', () => {
-        Module.prototype.require = originalRequire;
+        Module.prototype.require = MochaTestRunner.originalRequire;
         cb(err);
       });
 


### PR DESCRIPTION
This commit adds a convenience API `artifacts.require(name)` that aims to make
requiring artifacts a little bit more straight forward.

Usage:

```
const SimpleStorage = artifacts.require('SimpleStorage');
const EmbarkJS = artifacts.require('EmbarkJS');
```

### What did you refactor, implement, or fix?

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

#### How did you do it?

<!-- Provide a summary of the improvement/s you are submitting. -->

#### Is there anything that needs special attention (breaking changes, etc)?

<!-- Explain any special considerations. -->

### Questions

<!-- If relevant, write a list of questions that you would like to discuss related to your changes. -->

### Review

<!-- Use @mentions for quick questions, specific feedback, and progress updates. -->

### Cool Spaceship Picture

<!-- Star Trek/Wars, n/BSG, Voltron, Transformers... all welcome, but not all equally cool ;-) ->
