### PR TITLE
bugfix(@embark/console): fix included package files

### DIFF
--- a/packages/core/console/package.json
+++ b/packages/core/console/package.json
@@ -16,7 +16,7 @@
     "solidity"
   ],
   "files": [
-    "dist/lib"
+    "dist"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### What did you refactor, implement, or fix?

current issue with latest nightly `embark-console not found`, is due to the wrong directory being specified in package.json

### Cool Spaceship Picture

![https://steamuserimages-a.akamaihd.net/ugc/927057057117853966/427C178DF944A04140ABEEDE36766CA19C31FA4E/?imw=637&imh=358&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=true](https://steamuserimages-a.akamaihd.net/ugc/927057057117853966/427C178DF944A04140ABEEDE36766CA19C31FA4E/?imw=637&imh=358&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=true)