### PR TITLE
fix(@embark/contracts): fix ENS contracts not being resolved as deps

### DIFF
--- a/packages/stack/contracts-manager/src/index.js
+++ b/packages/stack/contracts-manager/src/index.js
@@ -263,7 +263,10 @@ export default class ContractsManager {
     const self = this;
 
     async.waterfall([
-      function prepareContractsFromConfig(callback) {
+      function beforeBuild(callback) {
+        self.plugins.emitAndRunActionsForEvent('contracts:build:before', callback);
+      },
+      function prepareContractsFromConfig(_options, callback) {
         self.events.emit("status", __("Building..."));
 
         if (contractsConfig.contracts.deploy) {


### PR DESCRIPTION
This was caused by the fact that we add the ENS contract to the
manager when before they deploy, but the dependency resolution was
done while building the contracts, so even before.
So the solution was to add a "before build" action so that the ENS
module could add its contracts to the manager if needed.