### PR TITLE
fix(@embark/ens): fix registerSubDomain in tests and add test

### DIFF
--- a/dapps/tests/app/test/embarkJS_spec.js
+++ b/dapps/tests/app/test/embarkJS_spec.js
@@ -20,12 +20,26 @@ config({
 });
 
 describe("EmbarkJS functions", function() {
-  it('should have access to ENS functions and registered test.eth', async function() {
-    const rootAddress = await EmbarkJS.Names.resolve('test.eth');
-    assert.strictEqual(rootAddress, web3.eth.defaultAccount);
+  it('should have access to ENS functions (register, lookup and resolve)', function(done) {
+    const registerAddr = web3.utils.toChecksumAddress('0x1a2f3b98e434c02363f3dac3174af93c1d690914');
+    EmbarkJS.Names.registerSubDomain('subdomain', registerAddr, async (err) => {
+      try {
+        assert.strictEqual(err, null);
 
-    const rootName = await EmbarkJS.Names.lookup(rootAddress);
-    assert.strictEqual(rootName, 'test.eth');
+        const rootAddress = await EmbarkJS.Names.resolve('test.eth');
+        assert.strictEqual(rootAddress, web3.eth.defaultAccount);
+
+        const rootName = await EmbarkJS.Names.lookup(rootAddress);
+        assert.strictEqual(rootName, 'test.eth');
+
+        const subRegisterAddr = await EmbarkJS.Names.resolve('subdomain.test.eth');
+        assert.strictEqual(subRegisterAddr, registerAddr);
+
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
   });
 
   it('should have access to Storage functions', async function() {
@@ -35,7 +49,11 @@ describe("EmbarkJS functions", function() {
   });
 
   it('should have access to Blockchain functions', async function() {
-    const contract = new EmbarkJS.Blockchain.Contract({abi: SimpleStorage.options.jsonInterface, address: SimpleStorage.options.address, web3: web3});
+    const contract = new EmbarkJS.Blockchain.Contract({
+      abi: SimpleStorage.options.jsonInterface,
+      address: SimpleStorage.options.address,
+      web3: web3
+    });
     const result = await contract.methods.get().call();
     assert.strictEqual(parseInt(result, 10), 100);
   });

--- a/packages/embarkjs/ens/src/index.js
+++ b/packages/embarkjs/ens/src/index.js
@@ -207,7 +207,6 @@ __embarkENS.web3 = new Web3();
 __embarkENS.setProvider = function(config) {
   const ERROR_MESSAGE = 'ENS is not available in this chain';
   this.registration = config.registration;
-  this.env = config.env;
   this.ready = false;
   this.dappAutoEnable = config.dappAutoEnable;
 
@@ -231,6 +230,7 @@ __embarkENS.setProvider = function(config) {
       const accounts = await this.web3.eth.getAccounts();
       this.web3.eth.defaultAccount = accounts[0];
       const id = await this.web3.eth.net.getId();
+      this.isKnownNetwork = !!this.registryAddresses[id];
       const registryAddress = this.registryAddresses[id] || config.registryAddress;
       this._isAvailable = true;
       this.ens = new this.web3.eth.Contract(config.registryAbi, registryAddress);
@@ -345,7 +345,7 @@ __embarkENS.registerSubDomain = function (name, address, callback) {
     return callback(defaultAccountNotSetError);
   }
 
-  if (this.env !== 'development' && this.env !== 'privatenet') {
+  if (this.isKnownNetwork) {
     return callback('Sub-domain registration is only available in development or privatenet mode');
   }
   if (!this.registration || !this.registration.rootDomain) {


### PR DESCRIPTION
registerSubDomain  didn't work in tests because it used the old way
of checking the env, which is checking the `this.env` string, but in
tests, we use the `test` env. So instead, we now check if it is a
known network using the network ID (like we do for other place)
