### PR TITLE
Make Ganache the default "blockchain" client

### DIFF
--- a/dapps/templates/boilerplate/config/blockchain.js
+++ b/dapps/templates/boilerplate/config/blockchain.js
@@ -4,10 +4,11 @@ module.exports = {
   // default applies to all environments
   default: {
     enabled: true,
-    client: "ganache-cli" // Can be ganache-cli, geth or parity (default: ganache-cli)
+    client: "geth" // Can be ganache-cli, geth or parity (default: geth)
   },
 
   development: {
+    client: "ganache-cli",
     clientConfig: {
       miningMode: 'dev' // Mode in which the node mines. Options: dev, auto, always, off
     }

--- a/dapps/templates/boilerplate/config/blockchain.js
+++ b/dapps/templates/boilerplate/config/blockchain.js
@@ -4,7 +4,7 @@ module.exports = {
   // default applies to all environments
   default: {
     enabled: true,
-    client: "geth" // Can be geth or parity (default:geth)
+    client: "ganache-cli" // Can be ganache-cli, geth or parity (default: ganache-cli)
   },
 
   development: {

--- a/dapps/templates/demo/config/blockchain.js
+++ b/dapps/templates/demo/config/blockchain.js
@@ -4,10 +4,11 @@ module.exports = {
   // default applies to all environments
   default: {
     enabled: true,
-    client: "ganache-cli" // Can be ganache-cli, geth or parity (default: ganache-cli)
+    client: "geth" // Can be ganache-cli, geth or parity (default: geth)
   },
 
   development: {
+    client: "ganache-cli",
     clientConfig: {
       miningMode: 'dev' // Mode in which the node mines. Options: dev, auto, always, off
     }

--- a/dapps/templates/demo/config/blockchain.js
+++ b/dapps/templates/demo/config/blockchain.js
@@ -15,7 +15,6 @@ module.exports = {
   },
 
   privatenet: {
-    client: 'geth',
     // Accounts to use as node accounts
     // The order here corresponds to the order of `web3.eth.getAccounts`, so the first one is the `defaultAccount`
     // For more account configurations, see: https://framework.embarklabs.io/docs/blockchain_accounts_configuration.html

--- a/dapps/templates/demo/config/blockchain.js
+++ b/dapps/templates/demo/config/blockchain.js
@@ -4,7 +4,7 @@ module.exports = {
   // default applies to all environments
   default: {
     enabled: true,
-    client: "geth" // Can be geth or parity (default:geth)
+    client: "ganache-cli" // Can be ganache-cli, geth or parity (default: ganache-cli)
   },
 
   development: {
@@ -14,6 +14,7 @@ module.exports = {
   },
 
   privatenet: {
+    client: 'geth',
     // Accounts to use as node accounts
     // The order here corresponds to the order of `web3.eth.getAccounts`, so the first one is the `defaultAccount`
     // For more account configurations, see: https://framework.embarklabs.io/docs/blockchain_accounts_configuration.html

--- a/dapps/tests/app/config/blockchain.js
+++ b/dapps/tests/app/config/blockchain.js
@@ -4,10 +4,11 @@ module.exports = {
   // default applies to all environments
   default: {
     enabled: true,
-    client: "ganache-cli" // Can be ganache-cli, geth or parity (default: ganache-cli)
+    client: "geth" // Can be ganache-cli, geth or parity (default: geth)
   },
 
   development: {
+    client: "ganache-cli",
     clientConfig: {
       miningMode: 'dev' // Mode in which the node mines. Options: dev, auto, always, off
     },

--- a/dapps/tests/app/config/blockchain.js
+++ b/dapps/tests/app/config/blockchain.js
@@ -4,7 +4,7 @@ module.exports = {
   // default applies to all environments
   default: {
     enabled: true,
-    client: "geth" // Can be geth or parity (default:geth)
+    client: "ganache-cli" // Can be ganache-cli, geth or parity (default: ganache-cli)
   },
 
   development: {

--- a/dapps/tests/app/test/another_storage_spec.js
+++ b/dapps/tests/app/test/another_storage_spec.js
@@ -12,6 +12,7 @@ config({
       {
         "mnemonic": "example exile argue silk regular smile grass bomb merge arm assist farm",
         balance: "5ether",
+        hdpath: "m/44'/1'/0'/0/",
         numAddresses: 10
       }
     ]
@@ -49,7 +50,6 @@ contract("AnotherStorage", function() {
 
     for (let i = 1; i < numAddresses - 3; i++) {
       balance = await web3.eth.getBalance(accounts[i]);
-      console.log('Account', i , balance);
       assert.strictEqual(parseInt(balance, 10), 5000000000000000000, `Account ${i} doesn't have the balance set`);
     }
   });

--- a/packages/core/core/constants.json
+++ b/packages/core/core/constants.json
@@ -40,7 +40,8 @@
     "call": "eth_call",
     "clients": {
       "geth": "geth",
-      "parity": "parity"
+      "parity": "parity",
+      "ganache": "ganache-cli"
     },
     "blockchainReady": "blockchainReady",
     "blockchainExit": "blockchainExit",

--- a/packages/core/core/src/configDefaults.ts
+++ b/packages/core/core/src/configDefaults.ts
@@ -10,7 +10,7 @@ export function getBlockchainDefaults(env) {
       miningMode: 'dev' // Mode in which the node mines. Options: dev, auto, always, off
     },
     enabled: true,
-    client: constants.blockchain.clients.geth,
+    client: constants.blockchain.clients.ganache,
     proxy: true,
     datadir: `.embark/${env}/datadir`,
     rpcHost: "localhost",

--- a/packages/core/engine/package.json
+++ b/packages/core/engine/package.json
@@ -88,6 +88,7 @@
     "embark-transaction-logger": "^5.1.1-nightly.2",
     "embark-transaction-tracker": "^5.1.1-nightly.2",
     "embark-utils": "^5.1.1-nightly.2",
+    "embark-vm-client": "^5.1.1-nightly.0",
     "embark-vyper": "^5.1.1-nightly.2",
     "embark-watcher": "^5.1.1-nightly.2",
     "embark-web3": "^5.1.1-nightly.2",

--- a/packages/core/engine/package.json
+++ b/packages/core/engine/package.json
@@ -88,7 +88,7 @@
     "embark-transaction-logger": "^5.1.1-nightly.2",
     "embark-transaction-tracker": "^5.1.1-nightly.2",
     "embark-utils": "^5.1.1-nightly.2",
-    "embark-vm-client": "^5.1.1-nightly.0",
+    "embark-vm-client": "^5.1.1-nightly.2",
     "embark-vyper": "^5.1.1-nightly.2",
     "embark-watcher": "^5.1.1-nightly.2",
     "embark-web3": "^5.1.1-nightly.2",

--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -267,6 +267,7 @@ export class Engine {
 
   blockchainComponents() {
     // plugins
+    this.registerModulePackage('embark-ganache');
     this.registerModulePackage('embark-geth', {
       client: this.client,
       locale: this.locale,
@@ -297,7 +298,6 @@ export class Engine {
   }
 
   contractsComponents(_options) {
-    this.registerModulePackage('embark-ganache');
     this.registerModulePackage('embark-ethereum-blockchain-client');
     this.registerModulePackage('embark-web3');
     this.registerModulePackage('embark-accounts-manager');

--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -243,6 +243,7 @@ export class Engine {
   blockchainStackComponents() {
     this.registerModulePackage('embark-blockchain', { plugins: this.plugins, ipc: this.ipc });
     this.registerModulePackage('embark-blockchain-client');
+    this.registerModulePackage('embark-vm-client');
     this.registerModulePackage('embark-process-logs-api-manager');
   }
 
@@ -256,6 +257,7 @@ export class Engine {
     this.registerModulePackage('embark-contracts-manager', { plugins: this.plugins, compileOnceOnly: options.compileOnceOnly });
     this.registerModulePackage('embark-deployment', { plugins: this.plugins, onlyCompile: options.onlyCompile });
     this.registerModulePackage('embark-blockchain-client');
+    this.registerModulePackage('embark-vm-client');
     this.registerModulePackage('embark-storage');
     this.registerModulePackage('embark-communication');
     this.registerModulePackage('embark-namesystem');

--- a/packages/core/engine/tsconfig.json
+++ b/packages/core/engine/tsconfig.json
@@ -134,6 +134,9 @@
       "path": "../../stack/test-runner"
     },
     {
+      "path": "../../stack/vm-client"
+    },
+    {
       "path": "../../stack/watcher"
     },
     {

--- a/packages/plugins/ethereum-blockchain-client/src/index.js
+++ b/packages/plugins/ethereum-blockchain-client/src/index.js
@@ -15,8 +15,6 @@ class EthereumBlockchainClient {
     this.events = embark.events;
     this.logger = embark.logger;
     this.fs = embark.fs;
-    this.contractsSubscriptions = [];
-    this.contractsEvents = [];
 
     this.logFile = dappPath(".embark", "contractEvents.json");
 

--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -10,15 +10,17 @@ class Ganache {
 
       const hasAccounts = blockchainConfig.accounts && blockchainConfig.accounts.length;
 
+      const isTest = embark.currentContext.includes('test');
+
       return ganache.provider({
         // Default to 8000000, which is the server default
         // Somehow, the provider default is 6721975
         gasLimit: blockchainConfig.targetGasLimit || '0x7A1200',
         blockTime: blockchainConfig.simulatorBlocktime,
         network_id:  blockchainConfig.networkId || 1337,
-        db_path: blockchainConfig.datadir,
-        default_balance_ether: hasAccounts ? null : '99999',
-        mnemonic: hasAccounts ? null : 'example exile argue silk regular smile grass bomb merge arm assist farm'
+        db_path: isTest ? '' : blockchainConfig.datadir,
+        default_balance_ether: '99999',
+        mnemonic: hasAccounts || isTest ? '' : 'example exile argue silk regular smile grass bomb merge arm assist farm'
       });
     });
   }

--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -2,10 +2,15 @@ class Ganache {
   constructor(embark) {
     embark.events.request('blockchain:vm:register', 'ganache-cli', () => {
       const ganache = require('ganache-cli');
-      // Default to 8000000, which is the server default
-      // Somehow, the provider default is 6721975
-      // TODO add configs from the blockchain config
-      return ganache.provider({gasLimit: '0x7A1200'});
+      const blockchainConfig = embark.config.blockchainConfig;
+
+      return ganache.provider({
+        // Default to 8000000, which is the server default
+        // Somehow, the provider default is 6721975
+        gasLimit: blockchainConfig.targetGasLimit || '0x7A1200',
+        blockTime: blockchainConfig.simulatorBlocktime,
+        network_id:  blockchainConfig.networkId
+      });
     });
   }
 }

--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -1,9 +1,10 @@
 class Ganache {
   constructor(embark) {
-    embark.events.request('blockchain:vm:register', () => {
+    embark.events.request('blockchain:vm:register', 'ganache-cli', () => {
       const ganache = require('ganache-cli');
       // Default to 8000000, which is the server default
       // Somehow, the provider default is 6721975
+      // TODO add configs from the blockchain config
       return ganache.provider({gasLimit: '0x7A1200'});
     });
   }

--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -4,12 +4,21 @@ class Ganache {
       const ganache = require('ganache-cli');
       const blockchainConfig = embark.config.blockchainConfig;
 
+      // Ensure the dir exists before initiating Ganache, because Ganache has a bug
+      // => https://github.com/trufflesuite/ganache-cli/issues/558
+      embark.fs.ensureDirSync(blockchainConfig.datadir);
+
+      const hasAccounts = blockchainConfig.accounts && blockchainConfig.accounts.length;
+
       return ganache.provider({
         // Default to 8000000, which is the server default
         // Somehow, the provider default is 6721975
         gasLimit: blockchainConfig.targetGasLimit || '0x7A1200',
         blockTime: blockchainConfig.simulatorBlocktime,
-        network_id:  blockchainConfig.networkId
+        network_id:  blockchainConfig.networkId || 1337,
+        db_path: blockchainConfig.datadir,
+        default_balance_ether: hasAccounts ? null : '99999',
+        mnemonic: hasAccounts ? null : 'example exile argue silk regular smile grass bomb merge arm assist farm'
       });
     });
   }

--- a/packages/plugins/ganache/tsconfig.json
+++ b/packages/plugins/ganache/tsconfig.json
@@ -8,5 +8,10 @@
   "extends": "../../../tsconfig.base.json",
   "include": [
     "src/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../core/utils"
+    }
   ]
 }

--- a/packages/plugins/ganache/tsconfig.json
+++ b/packages/plugins/ganache/tsconfig.json
@@ -8,10 +8,5 @@
   "extends": "../../../tsconfig.base.json",
   "include": [
     "src/**/*"
-  ],
-  "references": [
-    {
-      "path": "../../core/utils"
-    }
   ]
 }

--- a/packages/stack/blockchain-client/package.json
+++ b/packages/stack/blockchain-client/package.json
@@ -4,7 +4,7 @@
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Provides ability to register a blockchain technology in Embark, ie Ethereum.",
-  "homepage": "https://github.com/embarklabs/embark/blob/master/packages/stack/blockchain-client#readme",
+  "homepage": "https://github.com/embarklabs/embark/tree/master/packages/stack/blockchain-client#readme",
   "bugs": "https://github.com/embarklabs/embark/issues",
   "keywords": [
     "blockchain",

--- a/packages/stack/blockchain-client/package.json
+++ b/packages/stack/blockchain-client/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.7.4",
     "core-js": "3.4.3",
+    "embark-i18n": "^5.1.1-nightly.0",
     "web3": "1.2.6"
   },
   "devDependencies": {

--- a/packages/stack/blockchain-client/src/index.js
+++ b/packages/stack/blockchain-client/src/index.js
@@ -60,13 +60,6 @@ class BlockchainClient {
   }
 
   async _getProvider(clientName, endpoint) {
-    const blockchainClientName = this.config.blockchainConfig.client;
-    if (endpoint && this.getVmClient(blockchainClientName)) {
-      // TODO find a fix to detect if it 's the proxy
-      // Currently using a VM instead of a Node
-      const vm = await this.events.request2('blockchain:client:vmProvider', blockchainClientName);
-      return vm;
-    }
     // Passing in an endpoint allows us to customise which URL the provider connects to.
     // If no endpoint is provided, the provider will connect to the proxy.
     // Explicity setting an endpoint is useful for cases where we want to connect directly

--- a/packages/stack/blockchain-client/src/index.js
+++ b/packages/stack/blockchain-client/src/index.js
@@ -3,7 +3,6 @@ const { __ } = require('embark-i18n');
 const constants = require('embark-core/constants');
 
 class BlockchainClient {
-
   constructor(embark, _options) {
     this.embark = embark;
     this.events = embark.events;

--- a/packages/stack/blockchain-client/src/index.js
+++ b/packages/stack/blockchain-client/src/index.js
@@ -9,29 +9,6 @@ class BlockchainClient {
     this.events = embark.events;
     this.config = embark.config;
 
-    this.vms = [];
-    this.events.setCommandHandler("blockchain:vm:register", (name, handler) => {
-      this.vms.push({name, handler: handler()});
-    });
-
-    this.events.setCommandHandler("blockchain:client:vmProvider", async (vmName, cb) => {
-      if (typeof vmName === 'function') {
-        cb = vmName;
-        vmName = '';
-      }
-      if (!this.vms.length) {
-        return cb(`Failed to get the VM provider. Please register one using 'blockchain:vm:register', or by ensuring the 'embark-ganache' package is registered.`);
-      }
-      if (vmName) {
-        const vm = this.getVmClient(vmName);
-        if (!vm) {
-          return cb(__("No VM of name %s registered. Please register it using using 'blockchain:vm:register'", vmName));
-        }
-        return cb(null, vm.handler);
-      }
-      return cb(null, this.vms[this.vms.length - 1].handler);
-    });
-
     this.blockchainClients = {};
     this.client = null;
     this.events.setCommandHandler("blockchain:client:register", (clientName, blockchainClient) => {
@@ -53,10 +30,6 @@ class BlockchainClient {
       }
       cb(null, provider);
     });
-  }
-
-  getVmClient(vmName) {
-    return this.vms.find(vm => vm.name === vmName);
   }
 
   async _getProvider(clientName, endpoint) {

--- a/packages/stack/blockchain-client/tsconfig.json
+++ b/packages/stack/blockchain-client/tsconfig.json
@@ -8,5 +8,10 @@
   "extends": "../../../tsconfig.base.json",
   "include": [
     "src/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../core/i18n"
+    }
   ]
 }

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -63,6 +63,7 @@ export default class Blockchain {
         if (isStarted) {
           // Node may already be started
           params.started = true;
+          params.alreadyStarted = true;
           return cb(null, params);
         }
         // start node

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -48,7 +48,6 @@ export default class Blockchain {
       }
 
       const clientName = blockchainConfig.client;
-      console.log('STArting client', clientName);
       const started = () => {
         this.startedClient = clientName;
         this.events.emit("blockchain:started", clientName);
@@ -62,7 +61,6 @@ export default class Blockchain {
         const isVM = await this.events.request2('blockchain:client:vmProvider', clientName);
         if (isVM) {
           // The client is a vm
-          console.log('IS A VM');
           started();
           return cb();
         }
@@ -72,7 +70,10 @@ export default class Blockchain {
 
       const client = this.blockchainNodes[clientName];
 
-      if (!client) return cb(`Blockchain client '${clientName}' not found, please register this node using 'blockchain:node:register'.`);
+      if (!client) {
+        return cb(`Blockchain client '${clientName}' not found, please register this node using 'blockchain:node:register'.
+        \nIf ${clientName} is a VM, no need to use \`embark blockchain\`, Embark will connect to the VM directly during its run.`);
+      }
 
       // check if we should should start
       client.isStartedFn.call(client, (err, isStarted) => {

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -1,6 +1,5 @@
 import async from 'async';
 const { __ } = require('embark-i18n');
-const constants = require('embark-core/constants');
 
 import BlockchainAPI from "./api";
 export default class Blockchain {
@@ -52,11 +51,6 @@ export default class Blockchain {
         this.startedClient = clientName;
         this.events.emit("blockchain:started", clientName);
       };
-      // TODO remove VM once tests are refactored
-      if (clientName === constants.blockchain.vm) {
-        started();
-        return cb();
-      }
       try {
         const isVM = await this.events.request2('blockchain:client:vmProvider', clientName);
         if (isVM) {
@@ -104,7 +98,7 @@ export default class Blockchain {
 
       try {
         const isVM = await this.events.request2('blockchain:client:vmProvider', clientName);
-        if (clientName === constants.blockchain.vm || isVM) {
+        if (isVM) {
           this.startedClient = null;
           this.events.emit("blockchain:stopped", clientName);
           return cb();

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -1,4 +1,4 @@
-import { Embark, EmbarkEvents } from "embark-core";
+import { Embark, EmbarkEvents, EmbarkConfig } from "embark-core";
 import { __ } from "embark-i18n";
 import { Logger } from "embark-logger";
 import { buildUrl, findNextPort } from "embark-utils";
@@ -13,6 +13,7 @@ export default class ProxyManager {
   private wsProxy: any;
   private httpProxy: any;
   private plugins: any;
+  private config: EmbarkConfig;
   private readonly host: string;
   private rpcPort = 0;
   private wsPort = 0;
@@ -25,6 +26,7 @@ export default class ProxyManager {
     this.logger = embark.logger;
     this.events = embark.events;
     this.plugins = options.plugins;
+    this.config = embark.config;
 
     this.host = "localhost";
 
@@ -131,6 +133,7 @@ export default class ProxyManager {
       isWs: false,
       logger: this.logger,
       plugins: this.plugins,
+      config: this.config,
     })
       .serve(
         this.host,
@@ -144,6 +147,7 @@ export default class ProxyManager {
         isWs: true,
         logger: this.logger,
         plugins: this.plugins,
+        config: this.config,
       })
         .serve(
           this.host,

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -4,7 +4,6 @@ import { Logger } from "embark-logger";
 import { buildUrl, findNextPort } from "embark-utils";
 
 import { Proxy } from "./proxy";
-import {hasOwnProperty} from "tslint/lib/utils";
 
 const constants = require("embark-core/constants");
 

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -4,6 +4,7 @@ import { Logger } from "embark-logger";
 import { buildUrl, findNextPort } from "embark-utils";
 
 import { Proxy } from "./proxy";
+import {hasOwnProperty} from "tslint/lib/utils";
 
 const constants = require("embark-core/constants");
 
@@ -111,7 +112,7 @@ export default class ProxyManager {
     this.wsPort = wsPort;
 
     // setup proxy details
-    this.isWs = (/wss?/).test(this.embark.config.blockchainConfig.endpoint);
+    this.isWs = this.embark.config.blockchainConfig.endpoint ? (/wss?/).test(this.embark.config.blockchainConfig.endpoint) : true;
   }
 
   private async setupProxy(clientName: string) {
@@ -126,7 +127,6 @@ export default class ProxyManager {
     const endpoint = this.embark.config.blockchainConfig.endpoint;
 
     // HTTP
-    // TODO disable HTTP for VM?
     this.httpProxy = await new Proxy({
       endpoint,
       events: this.events,
@@ -153,7 +153,6 @@ export default class ProxyManager {
           this.host,
           this.wsPort,
         );
-      // TODO fix endpoint
       this.logger.info(`WS Proxy for node endpoint ${endpoint} listening on ${buildUrl("ws", this.host, this.wsPort, "ws")}`);
     }
   }

--- a/packages/stack/test-runner/src/lib/index.js
+++ b/packages/stack/test-runner/src/lib/index.js
@@ -298,7 +298,7 @@ class TestRunner {
     let node = options.node;
     if (!this.simOptions.host && (node && node === constants.blockchain.vm)) {
       this.simOptions.type = constants.blockchain.vm;
-      this.simOptions.client = constants.blockchain.vm;
+      this.simOptions.client = constants.blockchain.clients.ganache;
     } else if (this.simOptions.host || (node && node !== constants.blockchain.vm && node !== EMBARK_OPTION)) {
       let options = this.simOptions;
       if (node && node !== constants.blockchain.vm) {

--- a/packages/stack/vm-client/.npmrc
+++ b/packages/stack/vm-client/.npmrc
@@ -1,0 +1,4 @@
+engine-strict = true
+package-lock = false
+save-exact = true
+scripts-prepend-node-path = true

--- a/packages/stack/vm-client/README.md
+++ b/packages/stack/vm-client/README.md
@@ -1,0 +1,6 @@
+# `embark-vm-client`
+
+> Provides ability to register a VM technology in Embark, ie Ganache.
+
+Visit [framework.embarklabs.io](https://framework.embarklabs.io/) to get started with
+[Embark](https://github.com/embarklabs/embark).

--- a/packages/stack/vm-client/package.json
+++ b/packages/stack/vm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embark-vm-client",
-  "version": "5.1.0",
+  "version": "5.1.1-nightly.2",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Provides ability to register a VM technology in Embark, ie Ganache",
@@ -49,7 +49,7 @@
     "embark-i18n": "^5.1.1-nightly.0"
   },
   "devDependencies": {
-    "embark-solo": "^5.1.0",
+    "embark-solo": "^5.1.1-nightly.2",
     "eslint": "5.7.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.0"

--- a/packages/stack/vm-client/package.json
+++ b/packages/stack/vm-client/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "embark-blockchain-client",
-  "version": "5.1.1-nightly.2",
+  "name": "embark-vm-client",
+  "version": "5.1.0",
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
-  "description": "Provides ability to register a blockchain technology in Embark, ie Ethereum.",
-  "homepage": "https://github.com/embarklabs/embark/blob/master/packages/stack/blockchain-client#readme",
+  "description": "Provides ability to register a VM technology in Embark, ie Ganache",
+  "homepage": "https://github.com/embarklabs/embark/blob/master/packages/stack/vm-client#readme",
   "bugs": "https://github.com/embarklabs/embark/issues",
   "keywords": [
     "blockchain",
@@ -20,7 +20,7 @@
   ],
   "license": "MIT",
   "repository": {
-    "directory": "packages/stack/blockchain-client",
+    "directory": "packages/stack/vm-client",
     "type": "git",
     "url": "https://github.com/embarklabs/embark.git"
   },
@@ -46,11 +46,10 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.7.4",
     "core-js": "3.4.3",
-    "embark-i18n": "^5.1.1-nightly.0",
-    "web3": "1.2.6"
+    "embark-i18n": "^5.1.1-nightly.0"
   },
   "devDependencies": {
-    "embark-solo": "^5.1.1-nightly.2",
+    "embark-solo": "^5.1.0",
     "eslint": "5.7.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.0"

--- a/packages/stack/vm-client/package.json
+++ b/packages/stack/vm-client/package.json
@@ -4,7 +4,7 @@
   "author": "Iuri Matias <iuri.matias@gmail.com>",
   "contributors": [],
   "description": "Provides ability to register a VM technology in Embark, ie Ganache",
-  "homepage": "https://github.com/embarklabs/embark/blob/master/packages/stack/vm-client#readme",
+  "homepage": "https://github.com/embarklabs/embark/tree/master/packages/stack/vm-client#readme",
   "bugs": "https://github.com/embarklabs/embark/issues",
   "keywords": [
     "blockchain",

--- a/packages/stack/vm-client/src/index.js
+++ b/packages/stack/vm-client/src/index.js
@@ -42,6 +42,19 @@ class VMClient {
       }
       return cb(null, params);
     });
+
+    embark.registerActionForEvent("blockchain:node:stop", (params, cb) => {
+      if (params.stopped) {
+        return cb(null, params);
+      }
+      const clientName = params.clientName;
+      const isVM = this.getVmClient(clientName);
+      if (isVM) {
+        params.stopped = true;
+        params.isVM = true;
+      }
+      return cb(null, params);
+    });
   }
 
   getVmClient(vmName) {

--- a/packages/stack/vm-client/src/index.js
+++ b/packages/stack/vm-client/src/index.js
@@ -29,6 +29,18 @@ class VMClient {
       }
       return cb(null, this.vms[this.vms.length - 1].handler);
     });
+
+    embark.registerActionForEvent("blockchain:node:start", (params, cb) => {
+      if (params.started) {
+        return cb(null, params);
+      }
+      const clientName = params.blockchainConfig.client;
+      const isVM = this.getVmClient(clientName);
+      if (isVM) {
+        params.started = true;
+      }
+      return cb(null, params);
+    });
   }
 
   getVmClient(vmName) {

--- a/packages/stack/vm-client/src/index.js
+++ b/packages/stack/vm-client/src/index.js
@@ -1,0 +1,39 @@
+const { __ } = require('embark-i18n');
+
+class VMClient {
+
+  constructor(embark, _options) {
+    this.embark = embark;
+    this.events = embark.events;
+    this.config = embark.config;
+
+    this.vms = [];
+    this.events.setCommandHandler("blockchain:vm:register", (name, handler) => {
+      this.vms.push({name, handler: handler()});
+    });
+
+    this.events.setCommandHandler("blockchain:client:vmProvider", async (vmName, cb) => {
+      if (typeof vmName === 'function') {
+        cb = vmName;
+        vmName = '';
+      }
+      if (!this.vms.length) {
+        return cb(`Failed to get the VM provider. Please register one using 'blockchain:vm:register', or by ensuring the 'embark-ganache' package is registered.`);
+      }
+      if (vmName) {
+        const vm = this.getVmClient(vmName);
+        if (!vm) {
+          return cb(__("No VM of name %s registered. Please register it using using 'blockchain:vm:register'", vmName));
+        }
+        return cb(null, vm.handler);
+      }
+      return cb(null, this.vms[this.vms.length - 1].handler);
+    });
+  }
+
+  getVmClient(vmName) {
+    return this.vms.find(vm => vm.name === vmName);
+  }
+}
+
+module.exports = VMClient;

--- a/packages/stack/vm-client/src/index.js
+++ b/packages/stack/vm-client/src/index.js
@@ -38,6 +38,7 @@ class VMClient {
       const isVM = this.getVmClient(clientName);
       if (isVM) {
         params.started = true;
+        params.isVM = true;
       }
       return cb(null, params);
     });

--- a/packages/stack/vm-client/tsconfig.json
+++ b/packages/stack/vm-client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declarationDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./node_modules/.cache/tsc/tsconfig.embark-vm-client.tsbuildinfo"
+  },
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "references": [
+    {
+      "path": "../../core/i18n"
+    }
+  ]
+}

--- a/site/source/docs/blockchain_configuration.md
+++ b/site/source/docs/blockchain_configuration.md
@@ -16,9 +16,9 @@ If you want more configuration options, you can find them [here](/docs/blockchai
 module.exports = {
   default: {
     enabled: true,
-    client: "geth"
+    client: "ganache-cli"
   },
-  development: {  
+  development: {
     clientConfig: {
       miningMode: 'dev'
     }
@@ -41,7 +41,7 @@ Similar to [configuring Smart Contracts](/docs/contracts_configuration.html), th
 Most of the options are self-explanatory, still, here are some brief descriptions:
 
 Option | Type: `default` | Value
---- | --- | --- 
+--- | --- | ---
 `enabled` | boolean: `true` | Whether or not to spawn an Ethereum node
 `client` | string: `geth` |  Client to use for the Ethereum node. Currently supported: `geth` and `parity`
 `miningMode` | string: `dev` |  The mining mode to use for the node.<br/>`dev`: This is a special mode where the node uses a development account as defaultAccount. This account is already funded and transactions are faster.<br/>`auto`: Uses a mining script to mine only when needed.<br/>`always`: Miner is always on.<br/>`off`: Turns off the miner
@@ -54,8 +54,8 @@ Here are all the parameters you can use to customize your node. Note that they a
 
 We recommend putting those inside the `clientConfig` object a better structure.
 
-Option | Type: `default` | Value         
---- | --- | --- 
+Option | Type: `default` | Value
+--- | --- | ---
 `rpcHost` | string: `localhost` | Host the RPC server listens to
 `rpcPort` | number: `8545` | Port the RPC server listens to
 `rpcCorsDomain` | object | The CORS domains the node accepts
@@ -112,8 +112,8 @@ Note that we can always use the parameters we saw in the [Common parameters sect
 
 ### Parameter descriptions
 
-Option | Type: `value` | Description         
---- | --- | --- 
+Option | Type: `value` | Description
+--- | --- | ---
 `miningMode` | string: `auto` | You need to set `miningMode` to `auto` or `always` so you don't use the development mode
 `genesisBlock` | string |  File to start the chain in a clean state for your private network
 `accounts` | array |  Array of accounts to connect to. Go to the [Accounts configuration](/docs/blockchain_accounts_configuration.html) page to learn more on accounts
@@ -143,8 +143,8 @@ Here are the necessary parameters. Again, we can add more to override as you see
 
 ### Parameter descriptions
 
-Option | Type: `default` | Value         
---- | --- | --- 
+Option | Type: `default` | Value
+--- | --- | ---
 `networkType` | string: `testnet` | Again, used to specify the network. `testnet` here represents Ropsten. You can change the network by using a `networkId` by changing `networkType` to `custom`
 `syncMode` | string |  Blockchain sync mode
 `syncMode = 'light' `| |  Light clients synchronize a bare minimum of data and fetch necessary data on-demand from the network. Much lower in storage, potentially higher in bandwidth

--- a/site/source/docs/migrating_from_3.x.md
+++ b/site/source/docs/migrating_from_3.x.md
@@ -143,7 +143,7 @@ Here is an example of how simple your Blockchain configuration can look now:
 module.exports = {
   default: {
     enabled: true,
-    client: "geth"
+    client: "ganache-cli"
   },
 
   development: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -191,6 +191,9 @@
       "path": "packages/stack/test-runner"
     },
     {
+      "path": "packages/stack/vm-client"
+    },
+    {
       "path": "packages/stack/watcher"
     },
     {


### PR DESCRIPTION
### What did you refactor, implement, or fix?

Now, Ganache-cli is the default blockchain client. It uses the provider directly just like in tests.

#### How did you do it?

Changed the default config and the templates to use `ganache-cli` as the `client` instead of `geth`.
I also needed to modify how we  detect for a VM. Before, for the tests, we set `client` as `vm` and looked at that, but since we might support multiple VMs, this didn't work.

Instead, we request to see if the client name is part of the registered VMs, if so, abort trying to start a client, since it's a provider directly.
Then, the proxy does the same, request the VM provider, if there is none, it uses its endpoint to connect to the Node directly.

#### Is there anything that needs special attention (breaking changes, etc)?

This is not a breaking change, but it doesn't currently have 100% feature parity with Geth.
Example: some of the configs from the blockchain config are not passed to the provider yet, but we can implement those later. I didn't do it yet, because I focused on the ones we used for the simlator first.
Another problem I had is I can't manage to make the `db_path` property of Ganache work, meaning that there is no datadir used right now, so the contracts are redeployed each time. Somehow, when I set `db_path`, most commands stopped working, eg: getNetworkId()
Maybe related to Windows?

It's also not a breaking change, because all/most old projects already have `client: "geth"` defined in their blockchain config.

### Questions

Now that I implemented this, I think we could removed the `simulator` command. It doesn't serve any purpose, it is just slower. The only advantage currently is that you can restart `embark run` while keeping it running and the contracts will not be re-deployed (since Ganache is still running), but once we figure out the `db_path`, it shouldn't be a problem.



<!-- Star Trek/Wars, n/BSG, Voltron, Transformers... all welcome, but not all equally cool ;-) ->
