### PR TITLE
feat(core/engine): allow for disabling serviceMonitor activation

### DIFF
--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -155,6 +155,7 @@ export class Engine {
       blockchain: this.blockchainComponents,
       coreComponents: this.coreComponents,
       stackComponents: this.stackComponents,
+      serviceMonitor: this.serviceMonitor,
       consoleComponents: this.consoleComponents,
       blockchainStackComponents: this.blockchainStackComponents,
       compiler: this.compilerComponents,
@@ -196,15 +197,7 @@ export class Engine {
     });
   }
 
-  coreComponents() {
-
-    // TODO: should be made into a component
-    this.processManager = new ProcessManager({
-      events: this.events,
-      logger: this.logger,
-      plugins: this.plugins
-    });
-
+  serviceMonitor(options) {
     this.servicesMonitor = new ServicesMonitor({ events: this.events, logger: this.logger, plugins: this.plugins });
 
     if (this.servicesMonitor) {
@@ -220,6 +213,16 @@ export class Engine {
         });
       }
     }
+  }
+
+  coreComponents(options) {
+
+    // TODO: should be made into a component
+    this.processManager = new ProcessManager({
+      events: this.events,
+      logger: this.logger,
+      plugins: this.plugins
+    });
 
     this.registerModulePackage('embark-code-runner', { ipc: this.ipc });
 

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -61,6 +61,7 @@ class EmbarkController {
       Object.assign(engine.config.blockchainConfig, { isStandalone: true });
 
       engine.registerModuleGroup("coreComponents");
+      engine.registerModuleGroup("serviceMonitor");
       engine.registerModuleGroup("blockchainStackComponents");
       engine.registerModuleGroup("blockchain");
 
@@ -160,6 +161,7 @@ class EmbarkController {
       function (callback) {
 
         engine.registerModuleGroup("coreComponents");
+        engine.registerModuleGroup("serviceMonitor");
         engine.registerModuleGroup("stackComponents");
         engine.registerModuleGroup("consoleComponents");
 
@@ -374,6 +376,7 @@ class EmbarkController {
       },
       callback => {
         engine.registerModuleGroup("coreComponents");
+        engine.registerModuleGroup("serviceMonitor");
         engine.registerModuleGroup("stackComponents");
         engine.registerModuleGroup("consoleComponents");
 


### PR DESCRIPTION
`Engine`s internal `coreComponents()` API sets up a bunch of things like
a `ProcessManager` and the `ServiceMonitor`. The `ServiceMonitor` activates
itself on `embark:engine:started` and practically monitors registered services
until the process has been explicitly stopped.

There are some commands that don't actually need service monitoring like `build` and
a future `exec` command that's in the making. For those cases it's useful to have them
disable the service monitor when `coreComponents()` is used.

This commit introduces configuration options to `coreComponents()` with currently one
supported option: `disabledServiceMonitor` which defaults to `false`.

Usage:

```
engine.registerModuleGroup('coreComponents', {
  disableServiceMonitor: true
});
```

### What did you refactor, implement, or fix?

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

#### How did you do it?

<!-- Provide a summary of the improvement/s you are submitting. -->

#### Is there anything that needs special attention (breaking changes, etc)?

<!-- Explain any special considerations. -->

### Questions

<!-- If relevant, write a list of questions that you would like to discuss related to your changes. -->

### Review

<!-- Use @mentions for quick questions, specific feedback, and progress updates. -->

### Cool Spaceship Picture

<!-- Star Trek/Wars, n/BSG, Voltron, Transformers... all welcome, but not all equally cool ;-) ->
