### PR TITLE
fix(@embark/demo): fix ethereum not available in browser in the demo

### DIFF
--- a/dapps/templates/demo/app/components/blockchain.js
+++ b/dapps/templates/demo/app/components/blockchain.js
@@ -29,7 +29,6 @@ class Blockchain extends React.Component {
 
   async setValue(e) {
     e.preventDefault();
-    await EmbarkJS.enableEthereum();
     var value = parseInt(this.state.valueSet, 10);
 
     SimpleStorage.methods.set(value).send();


### PR DESCRIPTION
TLDR: Only affected Demo. We added `enableEthereum` randomly which wasn't needed

This only affected the demo. We somehow put the `enableEthereum()`
call right before the Demo `set` function, so since we now throw
when it's not available, it stopped the `set`. But it was never
needed because demo has `autoEnadble` on, meaning that `enable` is
called at the start.