### PR TITLE
fix@embark/cmd-controller): exit build if afterDeploy is not array

### DIFF
--- a/dapps/.gitignore
+++ b/dapps/.gitignore
@@ -3,3 +3,4 @@
 **/config/livenet/password
 **/config/production/password
 **/embarkArtifacts
+**/build

--- a/dapps/tests/contracts/contracts.js
+++ b/dapps/tests/contracts/contracts.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "default": {
     "versions": {
       "solc": "0.4.26"
@@ -18,9 +18,7 @@
       },
       "SimpleStorage": {
         "fromIndex": 0,
-        "args": [
-          100
-        ]
+        "args": [100]
       },
       "AnotherStorage": {
         "args": [
@@ -33,9 +31,7 @@
         "args": [1000]
       },
       "Test": {
-        "onDeploy": [
-          "Test.methods.changeAddress('$MyToken')"
-        ]
+        "onDeploy": ["Test.methods.changeAddress('$MyToken')"]
       },
       "MyToken": {
         "instanceOf": "Token"
@@ -64,10 +60,11 @@
         ]
       }
     },
-    "afterDeploy": [
-      "Test.methods.changeAddress('$MyToken')",
-      "web3.eth.getAccounts((err, accounts) => Test.methods.changeAddress(accounts[0]))"
-    ]
+    afterDeploy: async ({contracts, web3}) => {
+      await contracts.Test.methods.changeAddress(contracts.MyToken.options.address).send();
+      const accounts = await web3.eth.getAccounts();
+      await contracts.Test.methods.changeAddress(accounts[0]).send();
+    }
   },
   "development": {
     "deploy": {
@@ -77,4 +74,4 @@
       }
     }
   }
-}
+};

--- a/dapps/tests/contracts/embark.json
+++ b/dapps/tests/contracts/embark.json
@@ -5,7 +5,7 @@
   "app": {},
   "buildDir": "build/",
   "config": {
-    "contracts": "contracts.json",
+    "contracts": "contracts.js",
     "storage": false,
     "communication": false,
     "webserver": false,

--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -340,11 +340,12 @@ class EmbarkController {
       if (err) {
         engine.logger.error(err.message || err);
       }
-      // TODO: this should be moved out and determined somewhere else
-      if (!engine.config.contractsConfig.afterDeploy || !engine.config.contractsConfig.afterDeploy.length) {
+      if (!engine.config.contractsConfig.afterDeploy || !engine.config.contractsConfig.afterDeploy.length || !Array.isArray(engine.config.contractsConfig.afterDeploy)) {
         process.exit(err ? 1 : 0);
       }
       engine.logger.info(__('Waiting for after deploy to finish...'));
+      engine.logger.info(__('Embark would exit automatically if you were using the function syntax in your afterDeploy instead of the Array syntax.'));
+      engine.logger.info(__('Find more information here: %s', 'https://framework.embarklabs.io/docs/contracts_configuration.html#afterDeploy-hook'.underline));
       engine.logger.info(__('You can exit with CTRL+C when after deploy completes'));
     });
   }


### PR DESCRIPTION
Before, `embark build` would wait at the end if there was an
afterDeploy, because there was no way with the old string and array
syntax to know when the commands were done.
Now, with the function syntax, we can wait for the end.
This way, we can exit the build at the end if it is a function
afterDeploy.
Otherwise, we show a message saying that they should update