### PR TITLE
fix(@embark/blockchain-api): add back contract event listen and log

### DIFF
--- a/dapps/templates/demo/contracts/simple_storage.sol
+++ b/dapps/templates/demo/contracts/simple_storage.sol
@@ -3,12 +3,15 @@ pragma solidity ^0.6.0;
 contract SimpleStorage {
   uint public storedData;
 
+  event Set(address caller, uint _value);
+
   constructor(uint initialValue) public {
     storedData = initialValue;
   }
 
   function set(uint x) public {
     storedData = x;
+    emit Set(msg.sender, x);
   }
 
   function get() public view returns (uint retVal) {

--- a/packages/cockpit/ui/src/actions/index.js
+++ b/packages/cockpit/ui/src/actions/index.js
@@ -180,7 +180,7 @@ export const contractLogs = {
 export const CONTRACT_EVENTS = createRequestTypes('CONTRACT_EVENTS');
 export const contractEvents = {
   request: () => action(CONTRACT_EVENTS[REQUEST]),
-  success: (contractEvents) => action(CONTRACT_EVENTS[SUCCESS], {contractEvents}),
+  success: (contractEvents) => action(CONTRACT_EVENTS[SUCCESS], {contractEvents: contractEvents ? contractEvents.reverse() : []}),
   failure: (error) => action(CONTRACT_EVENTS[FAILURE], {error, name: 'contractEvents'})
 };
 

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -57,7 +57,7 @@ const { extendZeroAddressShorthand, replaceZeroAddressShorthand } = AddressUtils
 
 export { compact, last, recursiveMerge, groupBy } from './collections';
 export { prepareForCompilation } from './solidity/remapImports';
-export { File, getExternalContractUrl, Types } from './file';
+export { File, getExternalContractUrl, Types, getAppendLogFileCargo, getCircularReplacer, readAppendedLogs } from './file';
 
 export {
   findMonorepoPackageFromRoot,

--- a/packages/plugins/ethereum-blockchain-client/src/index.js
+++ b/packages/plugins/ethereum-blockchain-client/src/index.js
@@ -15,8 +15,6 @@ class EthereumBlockchainClient {
     this.events = embark.events;
     this.logger = embark.logger;
     this.fs = embark.fs;
-    this.contractsSubscriptions = [];
-    this.contractsEvents = [];
 
     this.logFile = dappPath(".embark", "contractEvents.json");
 

--- a/packages/stack/blockchain/src/api.ts
+++ b/packages/stack/blockchain/src/api.ts
@@ -248,10 +248,10 @@ export default class BlockchainAPI {
     this.embark.registerAPICall(
       "get",
       "/embark-api/blockchain/contracts/events",
-      (_req, res) => {
+      async (_req, res) => {
         try {
           const getEvents = this.getCallForBlockchain(blockchainName, "getEvents");
-          res.send(JSON.stringify(getEvents()));
+          res.send(await getEvents(true));
         } catch (error) {
           res.status(500).send({ error });
         }


### PR DESCRIPTION
### What did you refactor, implement, or fix?

Adds back the watch on contract events and writes them to a file
with the same method as contract logs from transaction-logger, so
I extracted those methods to utils/file so that both could use the
same functions.

### Questions

Seems like a lot of other functions `ethereum-blockchain-client/src/api.js` are not used, so there might be other cases like `getEvents` where the getter function "works", but it's always returning nothing because the setter function is never called.

Example: `subscribeToPendingTransactions` is never called. Is it no longer needed because we do that logic somewhere else? Or do we have an API that relies on those transactions that's now never returning anything? it,s hard to tell, because those functions come from before the refactor.

