### PR TITLE
chore(@embarkens): update ENS Registry mainnet address

### DIFF
--- a/packages/embarkjs/ens/src/index.js
+++ b/packages/embarkjs/ens/src/index.js
@@ -148,7 +148,7 @@ const voidAddress = '0x0000000000000000000000000000000000000000';
 
 __embarkENS.registryAddresses = {
   // Mainnet
-  "1": "0x314159265dd8dbb310642f98f50c066173c1259b",
+  "1": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
   // Ropsten
   "3": "0x112234455c3a32fd11230c42e7bccd4a84e02010",
   // Rinkeby

--- a/packages/plugins/ens/src/ensContractAddresses.js
+++ b/packages/plugins/ens/src/ensContractAddresses.js
@@ -5,7 +5,7 @@ const RINKEBY_ID = '4';
 export default {
   [MAINNET_ID]: {
     "ENSRegistry": {
-      "address": "0x314159265dd8dbb310642f98f50c066173c1259b",
+      "address": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
       "silent": true
     },
     "Resolver": {


### PR DESCRIPTION
Change address to the updated one because of a flaw found in the old