### PR TITLE
feat(@mbark/ens): enable the use of $accounts in registrations

### DIFF
--- a/dapps/tests/app/test/namesystem_spec.js
+++ b/dapps/tests/app/test/namesystem_spec.js
@@ -4,6 +4,8 @@ const MyToken = require('Embark/contracts/MyToken');
 const MyToken2 = require('Embark/contracts/MyToken2');
 const EmbarkJS = require('Embark/EmbarkJS');
 
+let accounts;
+
 config({
   namesystem: {
     enabled: true,
@@ -11,7 +13,8 @@ config({
       "rootDomain": "embark.eth",
       "subdomains": {
         "mytoken": "$MyToken",
-        "MyToken2": "$MyToken2"
+        "MyToken2": "$MyToken2",
+        "account": "$accounts[0]"
       }
     }
   },
@@ -30,15 +33,20 @@ config({
       }
     }
   }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
 });
 
 describe("ENS functions", function() {
   it('should allow directives in ENS subdomains', async function() {
     const myTokenAddress = await EmbarkJS.Names.resolve('mytoken.embark.eth');
-    assert.strictEqual(MyToken.options.address, myTokenAddress);
+    assert.strictEqual(myTokenAddress, MyToken.options.address);
 
     const myToken2Address = await EmbarkJS.Names.resolve('MyToken2.embark.eth');
-    assert.strictEqual(MyToken2.options.address, myToken2Address);
+    assert.strictEqual(myToken2Address, MyToken2.options.address);
+
+    const accountAddress = await EmbarkJS.Names.resolve('account.embark.eth');
+    assert.strictEqual(accountAddress, accounts[0]);
 
     const myTokenName = await EmbarkJS.Names.lookup(MyToken.options.address.toLowerCase());
     assert.strictEqual(myTokenName, 'mytoken.embark.eth');

--- a/site/source/docs/naming_configuration.md
+++ b/site/source/docs/naming_configuration.md
@@ -8,9 +8,11 @@ We can configure different naming systems in Embark. In this guide we'll explore
 
 Embark checks our configuration in `config/namesystem.js` by default. A naming system configuration isn't crucial to run Embark, so this only needs to be enabled when planing to use a naming system.
 
-When using ENS as our provider, we can set the `register` section to pre-register sub-domains. This feature is  only available in the development environment:
+When using ENS as our provider, we can set the `register` section to pre-register sub-domains.
 
-```
+This feature is  only available in the development environment:
+
+```javascript
 module.exports = {
   default: {
     enabled: true,
@@ -28,3 +30,34 @@ module.exports = {
   }
 };
 ```
+
+### Parameters
+
+- `rootDomain`: The ENS domain. It gets registered using your default account
+- `subdomains`: Object were the key is the subdomain name and the value is the address to set to it
+
+## Special configurations
+
+### $Contracts
+
+For subdomains, you can set the address as one of your contracts address using it's name prefixed by a dollar sign (`$`).
+
+```
+subdomains: {
+  'contract': '$MyContract'
+}
+```
+
+Now, assuming your `rootDomain` is `embark.eth`, `contract.embark.eth` will resolve to the deployed address of MyContract.
+
+### $accounts
+
+Similarly to `$Contract`, using `$accounts` let's you set the subdomain address to one of your accounts address.
+
+```
+subdomains: {
+  'account': '$accounts[0]'
+}
+```
+
+Now, assuming your `rootDomain` is `embark.eth`, `account.embark.eth` will resolve to address of your first (index 0) account (aka `defaultAccount`).


### PR DESCRIPTION
Enable putting `$accounts[i]` in subdomain registrations, where `i`
is the index of the `getAccounts` array.
This is the same behaviour we have for contract deployement
