### PR TITLE
fix(@embark/contracts-manager): Remove `logger` from serialized contract

### DIFF
--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -3,6 +3,8 @@ const https = require('follow-redirects').https;
 const shelljs = require('shelljs');
 const clipboardy = require('clipboardy');
 
+import * as Serialize from './serialize';
+export { Serialize };
 import { canonicalHost } from './host';
 export { canonicalHost, defaultCorsHost, defaultHost, dockerHostSwap, isDocker } from './host';
 export { downloadFile, findNextPort, getJson, httpGet, httpsGet, httpGetJson, httpsGetJson, pingEndpoint } from './network';

--- a/packages/core/utils/src/serialize.ts
+++ b/packages/core/utils/src/serialize.ts
@@ -1,0 +1,37 @@
+export function Serializable(target: any) {
+  target.prototype.toJSON = function() {
+    const props = Object.getOwnPropertyDescriptors(this);
+    const map = {};
+    Object.entries(props).map(([name, prop]) => {
+      if (Serialization.isIgnored(target.prototype, name)) {
+        return;
+      }
+      map[name] = prop.value;
+    });
+    return map;
+  };
+}
+
+export function Ignore(target: any, propertyKey: string) {
+  Serialization.registerIgnore(target, propertyKey);
+}
+
+class Serialization {
+  private static ignoreMap: Map<any, string[]> = new Map();
+  static registerIgnore(target: any, property: any): void {
+    let keys = this.ignoreMap.get(target);
+    if (!keys) {
+      keys = [];
+      this.ignoreMap.set(target, keys);
+    }
+    keys.push(property);
+  }
+
+  static isIgnored(target: any, property: any): boolean {
+    const keys = this.ignoreMap.get(target);
+    if (!keys) {
+      return false;
+    }
+    return keys.includes(property);
+  }
+}

--- a/packages/stack/contracts-manager/src/contract.ts
+++ b/packages/stack/contracts-manager/src/contract.ts
@@ -1,9 +1,11 @@
 import { ContractConfig } from "embark-core";
 import { Logger } from 'embark-logger';
-import { sha3 } from "embark-utils";
+import { sha3, Serialize } from "embark-utils";
 import { AbiItem } from "web3-utils";
 
+@Serialize.Serializable
 export default class Contract {
+  @Serialize.Ignore
   private logger: Logger;
   public abiDefinition?: AbiItem[];
   public deployedAddress?: string;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
+    "experimentalDecorators": true,
     "isolatedModules": true,
     "moduleResolution": "Node",
     "noImplicitAny": false,


### PR DESCRIPTION
### What did you refactor, implement, or fix?

For all instances where a `Contract` instance is serialized using `JSON.stringify`, the `logger` property was being stringified and written to logs and contract artifact files.

Add Serializer class that allows ignoring of class properties during serialization when using `JSON.stringify`.

#### How did you do it?

Created a static decorator class `Serializer` that can be used to decorate classes and class properties (and extended to methods, accessors, etc), which determine if a class property should be ignored when the class instance is serialized using `JSON.stringify`.

#### Is there anything that needs special attention (breaking changes, etc)?

NOTE: The `Serializer` relies on TypeScript’s decorators which are still listed as experimental (requiring the necessary compiler flag) despite being around for several years. Decorators are a stage 2 proposal for JavaScript.

### Cool Spaceship Picture
![Ancient aliens](http://www.otherworldmystery.com/wp-content/uploads/2011/ancient-aliens/vimana-carving.jpg)
