### PR TITLE
ci: use --coverage option when running `embark test` in test dapps

### DIFF
--- a/dapps/tests/app/package.json
+++ b/dapps/tests/app/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "ci": "npm run qa",
     "clean": "npm run reset",
-    "qa": "npm run test",
+    "qa": "npm run test -- --coverage",
     "reset": "npx embark-reset && npx rimraf embark-*.tgz package",
     "test": "npx embark test"
   },

--- a/dapps/tests/contracts/package.json
+++ b/dapps/tests/contracts/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "ci": "npm run qa",
     "clean": "npm run reset",
-    "qa": "npm run test",
+    "qa": "npm run test -- --coverage",
     "reset": "npx embark-reset && npx rimraf embark-*.tgz package",
     "test": "npx embark test"
   },


### PR DESCRIPTION
Avoid a situation where the `--coverage` option is not working (to an extent that `embark test --coverage` can't run successfully) but the problem goes undetected prior to the next stable release.

---

This PR is in draft because on `master` currently, and going back to at least the stable release of `5.0.0`, `embark test --coverage` in `dapps/tests/app` doesn't work correctly (there's an unhandled exception) and it hangs indefinitely. Once that bug has been fixed, this PR can be taken out of draft and merged.