### PR TITLE
build: update "qa:full" script in same manner as revised "ci:full"

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "preqa:full": "yarn install",
     "qa": "node scripts/monorun --ignore embark-dapp-* --stream qa",
     "qa:dapps": "lerna run --concurrency=1 --scope embark-dapp-* --stream qa",
-    "qa:full": "npm-run-all cwtree reboot:full cwtree \"qa -- --concurrency={1}\" qa:dapps cwtree -- 1",
+    "qa:full": "npm-run-all cwtree reboot:full cwtree typecheck \"lint -- --concurrency={1}\" build \"test -- --concurrency={1}\" qa:dapps cwtree -- 1",
     "reboot": "npm run clean",
     "reboot:full": "npm run clean:full",
     "release": "node scripts/release",


### PR DESCRIPTION
The `"qa:full"` script comes into play in the contexts of `scripts/release.js` (`npm run release`) and `scripts/stable-release.js` (`npm run release:stable`).