### PR TITLE
fix(@embark/ens): fix tests erroring on FIFS contract deploy

### DIFF
--- a/packages/plugins/ens/src/index.js
+++ b/packages/plugins/ens/src/index.js
@@ -279,7 +279,7 @@ class ENS {
     // Add contracts to contract manager so that they can be resolved as dependencies
     this.ensConfig.ENSRegistry = await this.events.request2('contracts:add', this.ensConfig.ENSRegistry);
     this.ensConfig.Resolver = await this.events.request2('contracts:add', this.ensConfig.Resolver);
-    this.ensConfig.FIFSRegistrar = await this.events.request2('contracts:add', this.ensConfig.FIFSRegistrar);
+    this.ensConfig.FIFSRegistrar = await this.events.request2('contracts:add', Object.assign({}, this.ensConfig.FIFSRegistrar, {deploy: false}));
     cb();
   }
 


### PR DESCRIPTION
Was caused by the contract being added in case another contract uses
it as a dependency, but it automatically tried to deploy with it, so
instead, set it as `deploy: false` until we see if we need to
register it