### PR TITLE
fix(@embark/logger): Make `dir` the same as all other logger functions

### DIFF
--- a/packages/core/logger/src/index.js
+++ b/packages/core/logger/src/index.js
@@ -204,16 +204,6 @@ export class Logger {
 
     this.events.emit("log", "dir", obj);
     this.logFunction(obj, null);
-
-    let origin;
-    if (this.isDebugOrTrace) {
-      try {
-        const stack = new Error().stack;
-        origin = stack.split('\n')[2].trim();
-      // eslint-disable-next-line no-empty
-      } catch (e) {}
-    }
-    this.writeToFile({ args: obj, origin, prefix: "[dir]" });
   }
 
   shouldLog(level) {


### PR DESCRIPTION
### What did you refactor, implement, or fix?

During the latest round of Logger updates, the `writeToFile` function was changed to an `async.cargo` queue and all `writeToFile` references should have been updated to push a a task to the queue.

The main issue was that the `dir` function was not upgraded to push a task to the `writeToFile` queue.

#### How did you do it?

Upgrade the `dir` function to push a task to the `writeToFile` queue to be in line with all other logger functions.

#### Is there anything that needs special attention (breaking changes, etc)?


### Questions


### Review


### Cool Spaceship Picture

![Ancient UFO](https://theearthexpanded.files.wordpress.com/2014/11/mayan_spaceship1.jpg)