### PR TITLE
fix(@embark/contracts-manager): always deploy contracts with deploy: true

### DIFF
--- a/packages/stack/contracts-manager/src/index.js
+++ b/packages/stack/contracts-manager/src/index.js
@@ -313,6 +313,9 @@ export default class ContractsManager {
             contract = new Contract(self.logger, contractConfig);
             contract.className = className;
             contract.args = [];
+            if (contractsConfig.strategy === constants.deploymentStrategy.explicit) {
+              contract.deploy = false;
+            }
           }
 
           contract.code = compiledContract.code;
@@ -353,14 +356,15 @@ export default class ContractsManager {
 
         for (className in self.contracts) {
           contract = self.contracts[className];
-          contract.deploy = (contract.deploy === undefined) || contract.deploy;
           if (self.deployOnlyOnConfig && !contractsConfig.contracts[className]) {
             contract.deploy = false;
           }
 
-          if (!contractsConfig.contracts[className] && contractsConfig.strategy === constants.deploymentStrategy.explicit) {
+          if (contract.deploy !== true && !contractsConfig.contracts[className] && contractsConfig.strategy === constants.deploymentStrategy.explicit) {
             contract.deploy = false;
           }
+
+          contract.deploy = contract.deploy ?? true;
 
           if (contract.code === "") {
             const message = __("assuming %s to be an interface", className);


### PR DESCRIPTION
### What did you refactor, implement, or fix?

This was an issue experienced with ENS contracts not being deployed
because the configs used `strategy: explicit` and ENS configs are
not in configs.

This fixes Teller with Embark.

#### How did you do it?

To fix, I changed the way we check for deploy. If `deploy` is set as
`true` it should always deploy even if not in configs. It just means
they were added from a plugin (like ENS)
Also, I needed to set to `false` the `deploy` property of contracts
compiled that were not in config, because otherwise, they tried to
deploy, which goes against the strategy. This is because those
contracts get initiated as `deploy: true`.