### PR TITLE
fix(stack/contracts-manager): ensure custom `abiDefinition` is set properly if provided

### DIFF
--- a/packages/stack/contracts-manager/src/index.js
+++ b/packages/stack/contracts-manager/src/index.js
@@ -325,7 +325,7 @@ export default class ContractsManager {
           contract.swarmHash = compiledContract.swarmHash;
           contract.gasEstimates = compiledContract.gasEstimates;
           contract.functionHashes = compiledContract.functionHashes;
-          contract.abiDefinition = compiledContract.abiDefinition;
+          contract.abiDefinition = contractConfig?.abiDefinition ?? compiledContract.abiDefinition;
           contract.filename = compiledContract.filename;
           contract.originalFilename = compiledContract.originalFilename || ("contracts/" + contract.filename);
           contract.path = dappPath(contract.originalFilename);


### PR DESCRIPTION
Turns out that https://github.com/embarklabs/embark/commit/17cec1b78701c37bc8c43dccee6093cbe28ff70b has never worked as intended.
Custom provided `abiDefinition` values have been simply ignored. Embark always used the
`abiDefnition` that resulted from the Smart Contract compilation.
