### PR TITLE
fix(@embark/deployment): fix undefined in web3 error message about number of arguments

### DIFF
--- a/packages/plugins/ethereum-blockchain-client/src/index.js
+++ b/packages/plugins/ethereum-blockchain-client/src/index.js
@@ -59,6 +59,16 @@ class EthereumBlockchainClient {
       const web3 = await this.web3;
       const [account] = await web3.eth.getAccounts();
       const contractObj = new web3.eth.Contract(contract.abiDefinition, contract.address);
+      contractObj._jsonInterface.find(obj => {
+        if (obj.type === 'constructor') {
+          if (!obj.name) {
+            // Add constructor as the name of the method, because if there is an error, it prints `undefined` otherwise
+            obj.name = 'constructor';
+          }
+          return true;
+        }
+        return false;
+      });
       const code = contract.code.substring(0, 2) === '0x' ? contract.code : "0x" + contract.code;
       const contractObject = contractObj.deploy({arguments: (contract.args || []), data: code});
       if (contract.gas === 'auto' || !contract.gas) {


### PR DESCRIPTION
This is caused by web3 using the method name to show which method
doesn't have the right number of arguments, but the constructor does
not have a name

Before:
```
[SimpleStorage]: Invalid number of parameters for "undefined". Got 0 expected 1!
```

After:
```
[SimpleStorage]: Invalid number of parameters for "constructor". Got 0 expected 1!
```
