### PR TITLE
Add Teller contracts to a new test Dapp for CI

### DIFF
--- a/dapps/tests/teller-contracts/contracts.js
+++ b/dapps/tests/teller-contracts/contracts.js
@@ -1,0 +1,240 @@
+const LICENSE_PRICE = "1000000000000000000"; // 10 * Math.pow(1, 18)
+const ARB_LICENSE_PRICE = "1000000000000000000"; // 10 * Math.pow(10, 18)
+const FEE_MILLI_PERCENT = "1000"; // 1 percent
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+const MAINNET_OWNER = "0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95";
+const RINKEBY_OWNER = "0xa019702a5743aFdd607c61321A90C43a8C1c69d9";
+const FALLBACK_ARBITRATOR_MAINNET = "0x35f7C96C392cD70ca5DBaeDB2005a946A82e8a95";
+const FALLBACK_ARBITRATOR_RINKEBY = "0xa019702a5743aFdd607c61321A90C43a8C1c69d9";
+const GAS_PRICE = "5000000000"; //5 gwei
+
+
+const dataMigration = require('./data.js');
+
+module.exports = {
+  default: {
+    dappConnection: [
+      "$EMBARK",
+      "$WEB3",
+      "ws://localhost:8546",
+      "http://localhost:8545"
+    ],
+
+    dappAutoEnable: false,
+
+    gas: "auto",
+
+    strategy: 'explicit',
+
+    deploy: {
+      Proxy: {
+        deploy: false
+      },
+      License: {
+        deploy: false
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: [
+          "$SNT",
+          LICENSE_PRICE,
+          "$KyberFeeBurner"  // TODO: replace with "$StakingPool"
+        ]
+      },
+      SellerLicenseInstance: {
+        instanceOf: "Proxy",
+        proxyFor: 'SellerLicense',
+        args: ["0x", "$SellerLicense"]
+      },
+      ArbitrationLicense: {
+        args: [
+          "$SNT",
+          ARB_LICENSE_PRICE,
+          "$KyberFeeBurner"  // TODO: replace with "$StakingPool"
+        ]
+      },
+      ArbitrationLicenseInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "ArbitrationLicense",
+        args: ["0x", "$ArbitrationLicense"]
+      },
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      Medianizer: {
+
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"]
+      },
+      UserStoreInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "UserStore",
+        args: ["0x", "$UserStore"]
+      },
+      OfferStoreInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "OfferStore",
+        args: ["0x", "$OfferStore"]
+      },
+      Escrow: {
+        args: ["$accounts[0]", FALLBACK_ARBITRATOR_MAINNET, "$ArbitrationLicense", "$OfferStore", "$UserStore", "$KyberFeeBurner", FEE_MILLI_PERCENT]
+      },
+      EscrowInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "Escrow",
+        args: ["0x", "$Escrow"]
+      },
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "Fees": {
+        "deploy": false
+      },
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+
+      /*
+      "StakingPool": {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: [
+          "$SNT"
+        ]
+      },
+      */
+
+      KyberNetworkProxy: {},
+      KyberFeeBurner: { // TODO: replace BURN_ADDRESS with "$StakingPool"
+        args: ["$SNT", BURN_ADDRESS, "$KyberNetworkProxy", "0x0000000000000000000000000000000000000000", "300"]
+      }
+    }
+  },
+
+  development: {
+    deploy: {
+      StandardToken: {},
+      DAI: {instanceOf: "StandardToken", onDeploy: ["DAI.methods.mint('$accounts[0]', '20000000000000000000').send()"]},
+      MKR: {instanceOf: "StandardToken", onDeploy: ["MKR.methods.mint('$accounts[0]', '20000000000000000000').send()"]}
+    },
+    afterDeploy: dataMigration.bind(null, GAS_PRICE, LICENSE_PRICE, ARB_LICENSE_PRICE, FEE_MILLI_PERCENT, BURN_ADDRESS, null, null)
+  },
+
+
+  testnet: {
+    gasPrice: GAS_PRICE,
+    tracking: 'shared.rinkeby.json',
+    afterDeploy: dataMigration.bind(null, GAS_PRICE, LICENSE_PRICE, ARB_LICENSE_PRICE, FEE_MILLI_PERCENT, BURN_ADDRESS, RINKEBY_OWNER, RINKEBY_OWNER),
+    dappConnection: [
+      "$WEB3",
+      "https://rinkeby.infura.io/v3/c26e9ab0df094a4f99bd1ea030eb7d50"
+    ],
+    deploy: {
+      StandardToken: {deploy: false},
+      DAI: {deploy: false},
+      MKR: {deploy: false},
+      KyberNetworkProxy: {
+        // https://developer.kyber.network/docs/Environments-Rinkeby/
+        address: "0xF77eC7Ed5f5B9a5aee4cfa6FFCaC6A4C315BaC76"
+      }
+    }
+  },
+
+  ropsten: {
+    gasPrice: "10000000000",
+    tracking: 'shared.ropsten.json',
+    deploy: {
+      SNT: {
+        address: "0xc55cf4b03948d7ebc8b9e8bad92643703811d162"
+      },
+      "MiniMeTokenFactory": {
+        deploy: false
+      },
+      KyberNetworkProxy: {
+        // https://developer.kyber.network/docs/Environments-Ropsten/
+        address: "0x818E6FECD516Ecc3849DAf6845e3EC868087B755"
+      }
+    },
+    afterDeploy: dataMigration.bind(null, GAS_PRICE, LICENSE_PRICE, ARB_LICENSE_PRICE, FEE_MILLI_PERCENT, BURN_ADDRESS, MAINNET_OWNER, FALLBACK_ARBITRATOR_RINKEBY),
+    dappConnection: ["$WEB3"]
+  },
+
+  // merges with the settings in default
+  // used with "embark run livenet"
+  livenet: {
+    gasPrice: GAS_PRICE,
+    tracking: 'shared.mainnet.json',
+    afterDeploy: dataMigration.bind(null, GAS_PRICE, LICENSE_PRICE, ARB_LICENSE_PRICE, FEE_MILLI_PERCENT, BURN_ADDRESS, MAINNET_OWNER, FALLBACK_ARBITRATOR_MAINNET),
+    dappConnection: [
+      "$WEB3",
+      "https://mainnet.infura.io/v3/c26e9ab0df094a4f99bd1ea030eb7d50"
+    ],
+    deploy: {
+      StandardToken: {deploy: false},
+      DAI: {deploy: false},
+      MKR: {deploy: false},
+      SNT: {
+        address: "0x744d70fdbe2ba4cf95131626614a1763df805b9e"
+      },
+      "MiniMeTokenFactory": {deploy: false},
+      KyberNetworkProxy: {
+        // https://developer.kyber.network/docs/Environments-Mainnet/
+        address: "0x818E6FECD516Ecc3849DAf6845e3EC868087B755"
+      },
+      SellerLicense: {
+        address: "0xD0fBD1a8D663B3D31312e0cb24910be82387266A"
+      },
+      SellerLicenseInstance: {
+        instanceOf: "Proxy",
+        proxyFor: 'SellerLicense',
+        address: "0x18C8e4570DE4D1FA07E2ad8BE4bc0Fe8B2C2dc4d"
+      },
+      ArbitrationLicense: {
+        address: "0x7e571b13aeb1a6abcfc470b7d033a6838e53f440"
+      },
+      ArbitrationLicenseInstance: {
+        instanceOf: "Proxy",
+        proxyFor: 'ArbitrationLicense',
+        address: "0x3e7fc31b9bd5fafde828acc1fd7b7b3dd7c1d927"
+      },
+      UserStore: {
+        address: "0x0ab611f28165a5b694959c1454c0a9027eae536d"
+      },
+      Medianizer: {
+        address: "0x729D19f657BD0614b4985Cf1D82531c67569197B"
+      },
+      OfferStore: {
+        address: "0x5EaE5D9Fc2F38d18D9F3Bfa584700801850670D0"
+      },
+      UserStoreInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "UserStore",
+        address: "0x61fbacebcef64e726ff5b848da5dff0c44c199f5"
+      },
+      OfferStoreInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "OfferStore",
+        address: "0xf0dfd170aedf576717b7de14dac257c832a364e2"
+      },
+      Escrow: {
+        address: "0x727bF4BAed69265bBaFD39f0ab6e508F6fA118a7"
+      },
+      EscrowInstance: {
+        instanceOf: "Proxy",
+        proxyFor: 'Escrow',
+        address: "0xD5baC31a10b8938dd47326f01802fa23f1032AeE"
+      },
+      KyberFeeBurner: {
+        address: "0x7702CaaE3D8feE750c4464d80FCb14Ce05e00743"
+      }
+    }
+  }
+};

--- a/dapps/tests/teller-contracts/contracts/common/Controlled.sol
+++ b/dapps/tests/teller-contracts/contracts/common/Controlled.sol
@@ -1,0 +1,22 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+contract Controlled {
+    /// @notice The address of the controller is the only address that can call
+    ///  a function with this modifier
+    modifier onlyController {
+        require(msg.sender == controller, "Unauthorized");
+        _;
+    }
+
+    address payable public controller;
+
+    constructor() internal {
+        controller = msg.sender;
+    }
+
+    /// @notice Changes the controller of the contract
+    /// @param _newController The new controller of the contract
+    function changeController(address payable _newController) public onlyController {
+        controller = _newController;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/Medianizer.sol
+++ b/dapps/tests/teller-contracts/contracts/common/Medianizer.sol
@@ -1,0 +1,15 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+
+/**
+ * @title Medianizer Mock Contract
+ */
+contract Medianizer {
+    function peek() public view returns (bytes32, bool) {
+        return (bytes32(0x000000000000000000000000000000000000000000000008c233113a8becc000), true);
+    }
+
+    function read() public view returns (bytes32) {
+        return bytes32(0x000000000000000000000000000000000000000000000008c233113a8becc000);
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/MessageSigned.sol
+++ b/dapps/tests/teller-contracts/contracts/common/MessageSigned.sol
@@ -1,0 +1,73 @@
+/* solium-disable no-empty-blocks */
+/* solium-disable security/no-inline-assembly */
+
+pragma solidity >=0.5.0 <0.6.0;
+
+
+/**
+ * @dev Uses ethereum signed messages
+ */
+contract MessageSigned {
+
+    constructor() internal {}
+
+    /**
+     * @dev recovers address who signed the message
+     * @param _signHash operation ethereum signed message hash
+     * @param _messageSignature message `_signHash` signature
+     */
+    function _recoverAddress(bytes32 _signHash, bytes memory _messageSignature)
+        internal
+        pure
+        returns(address)
+    {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        (v,r,s) = signatureSplit(_messageSignature);
+        return ecrecover(
+            _signHash,
+            v,
+            r,
+            s
+        );
+    }
+
+    /**
+     * @dev Hash a hash with `"\x19Ethereum Signed Message:\n32"`
+     * @param _hash Sign to hash.
+     * @return Hash to be signed.
+     */
+    function _getSignHash(bytes32 _hash) internal pure returns (bytes32 signHash) {
+        signHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", _hash));
+    }
+
+    /**
+     * @dev divides bytes signature into `uint8 v, bytes32 r, bytes32 s`
+     * @param _signature Signature string
+     */
+    function signatureSplit(bytes memory _signature)
+        internal
+        pure
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        require(_signature.length == 65, "Bad signature length");
+        // The signature format is a compact form of:
+        //   {bytes32 r}{bytes32 s}{uint8 v}
+        // Compact means, uint8 is not padded to 32 bytes.
+        assembly {
+            r := mload(add(_signature, 32))
+            s := mload(add(_signature, 64))
+            // Here we are loading the last 32 bytes, including 31 bytes
+            // of 's'. There is no 'mload8' to do this.
+            //
+            // 'byte' is not working due to the Solidity parser, so lets
+            // use the second best option, 'and'
+            v := and(mload(add(_signature, 65)), 0xff)
+        }
+        if (v < 27) {
+            v += 27;
+        }
+        require(v == 27 || v == 28, "Bad signature version");
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/Ownable.sol
+++ b/dapps/tests/teller-contracts/contracts/common/Ownable.sol
@@ -1,0 +1,83 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+     * account.
+     */
+    constructor () internal {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), _owner);
+    }
+
+    /**
+     * @dev is sender the owner of the contract?
+     * @return true if `msg.sender` is the owner of the contract.
+     */
+    function isOwner() public view returns (bool) {
+        return msg.sender == _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(isOwner(), "Only the contract's owner can invoke this function");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to relinquish control of the contract.
+     *      Renouncing to ownership will leave the contract without an owner.
+     *      It will not be possible to call the functions with the `onlyOwner`
+     *      modifier anymore.
+     */
+    function renounceOwnership() external onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param _newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address _newOwner) external onlyOwner {
+        _transferOwnership(_newOwner);
+    }
+
+    /**
+     * @dev Get the contract's owner
+     * @return the address of the owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Transfers control of the contract to a newOwner.
+     * @param _newOwner The address to transfer ownership to.
+     */
+    function _transferOwnership(address _newOwner) internal {
+        require(_newOwner != address(0), "New owner cannot be address(0)");
+        emit OwnershipTransferred(_owner, _newOwner);
+        _owner = _newOwner;
+    }
+
+    /**
+     * @dev Sets an owner address
+     * @param _newOwner new owner address
+     */
+    function _setOwner(address _newOwner) internal {
+        _owner = _newOwner;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/Pausable.sol
+++ b/dapps/tests/teller-contracts/contracts/common/Pausable.sol
@@ -1,0 +1,47 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Ownable.sol";
+
+/**
+ * @title Pausable
+ * @dev Makes contract functions pausable by the owner
+ */
+contract Pausable is Ownable {
+
+    event Paused();
+    event Unpaused();
+
+    bool public paused;
+
+    constructor () internal {
+        paused = false;
+    }
+
+    modifier whenNotPaused() {
+        require(!paused, "Contract must be unpaused");
+        _;
+    }
+
+    modifier whenPaused() {
+        require(paused, "Contract must be paused");
+        _;
+    }
+
+    /**
+     * @dev Disables contract functions marked with "whenNotPaused" and enables the use of functions marked with "whenPaused"
+     *      Only the owner of the contract can invoke this function
+     */
+    function pause() external onlyOwner whenNotPaused {
+        paused = true;
+        emit Paused();
+    }
+
+    /**
+     * @dev Enables contract functions marked with "whenNotPaused" and disables the use of functions marked with "whenPaused"
+     *      Only the owner of the contract can invoke this function
+     */
+    function unpause() external onlyOwner whenPaused {
+        paused = false;
+        emit Unpaused();
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/ReentrancyGuard.sol
+++ b/dapps/tests/teller-contracts/contracts/common/ReentrancyGuard.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+
+contract ReentrancyGuard {
+
+    bool public locked = false;
+
+    /**
+     * @dev Use this modifier on functions susceptible to reentrancy attacks
+     */
+    modifier reentrancyGuard() {
+        require(!locked, "Reentrant call detected!");
+        locked = true;
+        _;
+        locked = false;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/SecuredFunctions.sol
+++ b/dapps/tests/teller-contracts/contracts/common/SecuredFunctions.sol
@@ -1,0 +1,28 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../common/Ownable.sol";
+
+
+contract SecuredFunctions is Ownable {
+
+    mapping(address => bool) public allowedContracts;
+
+    /// @notice Only allowed addresses and the same contract can invoke this function
+    modifier onlyAllowedContracts {
+        require(allowedContracts[msg.sender] || msg.sender == address(this), "Only allowed contracts can invoke this function");
+        _;
+    }
+
+    /**
+     * @dev Set contract addresses with special privileges to execute special functions
+     * @param _contract Contract address
+     * @param _allowed Is contract allowed?
+     */
+    function setAllowedContract (
+        address _contract,
+        bool _allowed
+    ) public onlyOwner
+    {
+        allowedContracts[_contract] = _allowed;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/common/Stakable.sol
+++ b/dapps/tests/teller-contracts/contracts/common/Stakable.sol
@@ -1,0 +1,157 @@
+/* solium-disable security/no-call-value */
+
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../common/Ownable.sol";
+import "../token/ERC20Token.sol";
+import "../token/SafeTransfer.sol";
+
+
+contract Stakable is Ownable, SafeTransfer {
+    address payable public burnAddress;
+
+    struct Stake {
+        uint amount;
+        address payable owner;
+        address token;
+    }
+
+    mapping(uint => Stake) public stakes;
+    mapping(address => uint) public stakeCounter;
+
+    event BurnAddressChanged(address sender, address prevBurnAddress, address newBurnAddress);
+
+    event Staked(uint indexed itemId, address indexed owner, uint amount);
+    event Unstaked(uint indexed itemId, address indexed owner, uint amount);
+    event Slashed(uint indexed itemId, address indexed owner, address indexed slasher, uint amount);
+
+    /**
+     * @param _burnAddress Address where the slashed stakes are going to be sent
+     */
+    constructor(address payable _burnAddress) internal {
+        burnAddress = _burnAddress;
+    }
+
+    /**
+     * @dev Changes the burn address
+     * @param _burnAddress New burn address
+     */
+    function setBurnAddress(address payable _burnAddress) external onlyOwner {
+        emit BurnAddressChanged(msg.sender, burnAddress, _burnAddress);
+        burnAddress = _burnAddress;
+    }
+
+    /**
+     * @notice Get amount to stake for the next offer
+     * @param _owner Address for which the stake amount will be calculated
+     * @return Amount to stake in wei
+     */
+    function getAmountToStake(address _owner) public view returns(uint);
+
+    /**
+     * @dev Stake eth amount for an item
+     * @param _itemId Identifier of the item that will have a stake
+     * @param _owner Owner of the stake
+     * @param _tokenAddress Asset used for the stake (ignored in this version)
+     */
+    function _stake(uint _itemId, address payable _owner, address _tokenAddress) internal {
+        require(stakes[_itemId].owner == address(0), "Already has/had a stake");
+
+        uint stakeAmount = getAmountToStake(_owner);
+        require(msg.value >= stakeAmount, "More ETH is required");
+
+        stakeCounter[_owner]++;
+        // Using only ETH as stake for phase 0
+        address tokenAddress = address(0);
+
+
+        stakes[_itemId].amount = msg.value;
+        stakes[_itemId].owner = _owner;
+        stakes[_itemId].token = tokenAddress;
+
+        emit Staked(_itemId,  _owner, stakeAmount);
+    }
+
+    /**
+     * @dev Remove stake from item
+     * @param _itemId Identifier of the item that has a stake
+     */
+    function _unstake(uint _itemId) internal {
+        Stake storage s = stakes[_itemId];
+
+        if (s.amount == 0) {
+            return; // No stake for item
+        }
+
+        uint amount = s.amount;
+        s.amount = 0;
+
+        assert(stakeCounter[s.owner] > 0);
+        stakeCounter[s.owner]--;
+
+        if (s.token == address(0)) {
+            (bool success, ) = s.owner.call.value(amount)("");
+            require(success, "Transfer failed.");
+        } else {
+            require(_safeTransfer(ERC20Token(s.token), s.owner, amount), "Couldn't transfer funds");
+        }
+
+        emit Unstaked(_itemId, s.owner, amount);
+    }
+
+    /**
+     * @dev Slash a stake, sending the funds to the burn address
+     * @param _itemId Identifier of the item that has a stake
+     */
+    function _slash(uint _itemId) internal {
+        Stake storage s = stakes[_itemId];
+
+        if (s.amount == 0) {
+            return;
+        }
+
+        uint amount = s.amount;
+        s.amount = 0;
+
+        if (s.token == address(0)) {
+            (bool success, ) = burnAddress.call.value(amount)("");
+            require(success, "Transfer failed.");
+        } else {
+            require(_safeTransfer(ERC20Token(s.token), burnAddress, amount), "Couldn't transfer funds");
+        }
+
+        emit Slashed(
+            _itemId,
+            s.owner,
+            msg.sender,
+            amount
+        );
+    }
+
+    /**
+     * @dev Refund stake funds to its owner
+     * @param _itemId Identifier of the item that has a stake
+     */
+    function _refundStake(uint _itemId) internal {
+        Stake storage s = stakes[_itemId];
+
+        if (s.amount == 0) {
+            return;
+        }
+
+        uint amount = s.amount;
+        s.amount = 0;
+
+        stakeCounter[s.owner]--;
+
+        if (amount != 0) {
+            if (s.token == address(0)) {
+                (bool success, ) = s.owner.call.value(amount)("");
+                require(success, "Transfer failed.");
+            } else {
+                require(_safeTransfer(ERC20Token(s.token), s.owner, amount), "Couldn't transfer funds");
+            }
+        }
+    }
+
+}

--- a/dapps/tests/teller-contracts/contracts/common/USDStakable.sol
+++ b/dapps/tests/teller-contracts/contracts/common/USDStakable.sol
@@ -1,0 +1,67 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Stakable.sol";
+import "./Medianizer.sol";
+
+
+/**
+ * @title USDStakable
+ * @dev Staking contract that is integrated with MakerDAO's medianizer to obtain stake prices in USD, with initial price being always ~1USD
+ */
+contract USDStakable is Stakable {
+    Medianizer public medianizer;
+    uint public basePrice;
+
+    /**
+     * @param _burnAddress Address where the slashed stakes are going to be sent
+     * @param _medianizer Medianizer contract address
+     */
+    constructor(address payable _burnAddress, address _medianizer) internal Stakable(_burnAddress) {
+        burnAddress = _burnAddress;
+        basePrice = 1 ether;  // 1 usd
+        medianizer = Medianizer(_medianizer);
+    }
+
+    event BasePriceChanged(address sender, uint prevPrice, uint newPrice);
+
+    /**
+     * @dev Changes the base price
+     * @param _basePrice New burn address
+     */
+    function setBasePrice(uint _basePrice) external onlyOwner {
+        emit BasePriceChanged(msg.sender, basePrice, _basePrice);
+        basePrice = _basePrice;
+    }
+
+    event MedianizerChanged(address sender, address _oldAddress, address _newAddress);
+
+    /**
+     * @dev Changes the medianizer address
+     * @param _medianizer New medianizer address
+     */
+    function setMedianizer(address _medianizer) external onlyOwner {
+        emit MedianizerChanged(msg.sender, address(medianizer), _medianizer);
+        medianizer = Medianizer(_medianizer);
+    }
+
+    /**
+     * @notice Get amount to stake for the next offer
+     * @param _owner Address for which the stake amount will be calculated
+     * @return Amount to stake in wei
+     */
+    function getAmountToStake(address _owner) public view returns(uint) {
+        uint stakeCnt = stakeCounter[_owner] + 1;
+
+        uint mweiPrice = basePrice * 1000000;
+        uint daiPrice = uint256(medianizer.read());
+        uint oneUsdEth = (mweiPrice / daiPrice) * 1 szabo;
+
+        uint amountToStake = oneUsdEth * (stakeCnt * stakeCnt) / 17; // y = basePrice * x^2/17
+
+        if (amountToStake < oneUsdEth) {
+            return oneUsdEth;
+        }
+
+        return amountToStake;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/fees/KyberFeeBurner.sol
+++ b/dapps/tests/teller-contracts/contracts/fees/KyberFeeBurner.sol
@@ -1,0 +1,186 @@
+/* solium-disable security/no-block-members */
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../common/Ownable.sol";
+import "../token/ERC20Token.sol";
+import "../token/SafeTransfer.sol";
+import "./KyberNetworkProxy.sol";
+
+/**
+ * @title KyberFeeBurner
+ * @dev Contract that holds assets for the purpose of trading them to SNT and burning them
+ * @dev Assets come from the Escrow contract fees
+ */
+contract KyberFeeBurner is Ownable, SafeTransfer {
+
+    address public SNT;
+    address public burnAddress;
+    address public walletId;
+    KyberNetworkProxy public kyberNetworkProxy;
+    uint public maxSlippageRate;
+
+    // In Kyber's contracts, this is the address for ETH
+    address constant internal ETH_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /**
+     * @param _snt Address of the SNT contract
+     * @param _burnAddress Address where to burn the assets
+     * @param _kyberNetworkProxy License contract instance address for arbitrators
+     * @param _walletId Wallet address to send part of the fees to (used for the fee sharing program)
+     * @param _maxSlippageRate Max slippage rate to accept a trade
+     */
+    constructor(address _snt, address _burnAddress, address _kyberNetworkProxy, address _walletId, uint _maxSlippageRate) public {
+        SNT = _snt;
+        burnAddress = _burnAddress;
+        kyberNetworkProxy = KyberNetworkProxy(_kyberNetworkProxy);
+        walletId = _walletId;
+
+        setMaxSlippageRate(_maxSlippageRate);
+    }
+
+    event SNTAddressChanged(address sender, address prevSNTAddress, address newSNTAddress);
+
+    /**
+     * @dev Changes the SNT contract address
+     * @param _snt New SNT contract address
+     */
+    function setSNT(address _snt) external onlyOwner {
+        emit SNTAddressChanged(msg.sender, SNT, _snt);
+        SNT = _snt;
+    }
+
+    event BurnAddressChanged(address sender, address prevBurnAddress, address newBurnAddress);
+
+    /**
+     * @dev Changes the burn address
+     * @param _burnAddress New burn address
+     */
+    function setBurnAddress(address _burnAddress) external onlyOwner {
+        emit BurnAddressChanged(msg.sender, burnAddress, _burnAddress);
+        burnAddress = _burnAddress;
+    }
+
+    event KyberNetworkProxyAddressChanged(address sender, address prevKyberAddress, address newKyberAddress);
+
+    /**
+     * @dev Changes the KyberNetworkProxy contract address
+     * @param _kyberNetworkProxy New KyberNetworkProxy address
+     */
+    function setKyberNetworkProxyAddress(address _kyberNetworkProxy) external onlyOwner {
+        emit KyberNetworkProxyAddressChanged(msg.sender, address(kyberNetworkProxy), _kyberNetworkProxy);
+        kyberNetworkProxy = KyberNetworkProxy(_kyberNetworkProxy);
+    }
+
+    event WalletIdChanged(address sender, address prevWalletId, address newWalletId);
+
+    /**
+     * @dev Changes the walletId address (for the fee sharing program)
+     * @param _walletId New walletId address
+     */
+    function setWalletId(address _walletId) external onlyOwner {
+        emit WalletIdChanged(msg.sender, walletId, _walletId);
+        walletId = _walletId;
+    }
+
+    /**
+     * @dev Changes the current max slippage rate
+     * @param _newSlippageRate New slippage rate
+     */
+    function setMaxSlippageRate(uint _newSlippageRate) public onlyOwner {
+        require(_newSlippageRate <= 10000, "Invalid slippage rate");
+        emit SlippageRateChanged(msg.sender, maxSlippageRate, _newSlippageRate);
+        maxSlippageRate = _newSlippageRate;
+    }
+
+    event SlippageRateChanged(address sender, uint oldRate, uint newRate);
+
+    event Swap(address sender, address srcToken, address destToken, uint srcAmount, uint destAmount);
+
+
+    /**
+     * @dev Swaps the total balance of the selected asset to SNT and transfers it to the burn address
+     * @param _token Address of the asset to trade
+     */
+    function swap(address _token) public {
+        if (_token == address(0)) {
+            swap(_token, address(this).balance);
+        } else {
+            ERC20Token t = ERC20Token(_token);
+            swap(_token, t.balanceOf(address(this)));
+        }
+    }
+
+    /**
+     * @dev Swaps the selected asset to SNT and transfers it to the burn address
+     * @param _token Address of the asset to trade
+     * @param _amount Amount to swap
+     */
+    function swap(address _token, uint _amount) public {
+        uint tokensToTradeRate;
+        uint ratePer1Token;
+        uint minAcceptedRate;
+
+        uint destAmount;
+
+        if (_token == address(0)) {
+            require(_amount <= address(this).balance, "Invalid amount");
+
+            (ratePer1Token,) = kyberNetworkProxy.getExpectedRate(ETH_TOKEN_ADDRESS, SNT, 1 ether);
+            (tokensToTradeRate,) = kyberNetworkProxy.getExpectedRate(ETH_TOKEN_ADDRESS, SNT, _amount);
+            minAcceptedRate = (ratePer1Token * (10000 - maxSlippageRate)) / 10000;
+            require(tokensToTradeRate >= minAcceptedRate, "Rate is not acceptable");
+
+            destAmount = kyberNetworkProxy.trade.value(_amount)(ETH_TOKEN_ADDRESS, _amount, SNT, burnAddress, 0 - uint256(1), tokensToTradeRate, walletId);
+            emit Swap(msg.sender, ETH_TOKEN_ADDRESS, SNT, _amount, destAmount);
+        } else {
+            ERC20Token t = ERC20Token(_token);
+            require(_amount <= t.balanceOf(address(this)), "Invalid amount");
+
+            if (_token == SNT) {
+                require(_safeTransfer(t, burnAddress, _amount), "SNT transfer failure");
+                emit Swap(msg.sender, SNT, SNT, _amount, _amount);
+                return;
+            } else {
+                // Mitigate ERC20 Approve front-running attack, by initially setting allowance to 0
+                require(ERC20Token(_token).approve(address(kyberNetworkProxy), 0), "Failed to reset approval");
+
+                // Set the spender's token allowance to tokenQty
+                require(ERC20Token(_token).approve(address(kyberNetworkProxy), _amount), "Failed to approve trade amount");
+
+                (ratePer1Token,) = kyberNetworkProxy.getExpectedRate(_token, SNT, 1 ether);
+                (tokensToTradeRate,) = kyberNetworkProxy.getExpectedRate(_token, SNT, _amount);
+                minAcceptedRate = (ratePer1Token * (10000 - maxSlippageRate)) / 10000;
+                require(tokensToTradeRate >= minAcceptedRate, "Rate is not acceptable");
+
+                destAmount = kyberNetworkProxy.trade(_token, _amount, SNT, burnAddress, 0 - uint256(1), tokensToTradeRate, walletId);
+
+                emit Swap(msg.sender, _token, SNT, _amount, destAmount);
+            }
+        }
+    }
+
+    event EscapeTriggered(address sender, address token, uint amount);
+
+    /**
+     * @dev Exits the selected asset to the owner
+     * @param _token Address of the asset to exit
+     */
+    function escape(address _token) external onlyOwner {
+        if (_token == address(0)) {
+            uint ethBalance = address(this).balance;
+            address ownerAddr = address(uint160(owner()));
+            (bool success, ) = ownerAddr.call.value(ethBalance)("");
+            require(success, "Transfer failed.");
+            emit EscapeTriggered(msg.sender, _token, ethBalance);
+        } else {
+            ERC20Token t = ERC20Token(_token);
+            uint tokenBalance = t.balanceOf(address(this));
+            require(_safeTransfer(t, owner(), tokenBalance), "Token transfer error");
+            emit EscapeTriggered(msg.sender, _token, tokenBalance);
+        }
+    }
+
+    function() payable external {
+    }
+
+}

--- a/dapps/tests/teller-contracts/contracts/fees/KyberNetworkProxy.sol
+++ b/dapps/tests/teller-contracts/contracts/fees/KyberNetworkProxy.sol
@@ -1,0 +1,67 @@
+pragma solidity >=0.5.0 <0.6.0;
+/**
+ * @title KyberNetworkProxy
+ * @dev Mock of the KyberNetworkProxy. Only used in development
+ */
+contract KyberNetworkProxy {
+
+    constructor() public {
+    }
+
+    /**
+     * @dev Get a mocked up rate for the trade
+     */
+    function getExpectedRate(
+        address /* src */,
+        address /* dest */,
+        uint /* srcQty */
+        )
+        public pure
+        returns(uint expectedRate, uint slippageRate)
+    {
+        return (32749000000000000000, 31766530000000000000);
+    }
+
+    /// @notice use token address ETH_TOKEN_ADDRESS for ether
+    /// @dev makes a trade between src and dest token and send dest token to destAddress
+    /// @param maxDestAmount A limit on the amount of dest tokens
+    /// @return amount of actual dest tokens
+    function trade(
+        address /* src */,
+        uint /* srcAmount */,
+        address /* dest */,
+        address /* destAddress */,
+        uint  maxDestAmount,
+        uint /* minConversionRate */,
+        address /* walletId */
+    )
+        public
+        payable
+        returns(uint)
+    {
+      return maxDestAmount;
+    }
+
+    /// @dev makes a trade between src and dest token and send dest tokens to msg sender
+    /// @return amount of actual dest tokens
+    function swapTokenToToken(
+        address /* src */,
+        uint /* srcAmount */,
+        address /* dest */,
+        uint /* minConversionRate */
+    )
+        public pure
+        returns(uint)
+    {
+        return 100;
+    }
+
+    /// @dev makes a trade from Ether to token. Sends token to msg sender
+    /// @return amount of actual dest tokens
+    function swapEtherToToken(
+        address /* token */,
+        uint /* minConversionRate */
+    ) public payable returns(uint) {
+        return 200;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/proxy/Proxiable.sol
+++ b/dapps/tests/teller-contracts/contracts/proxy/Proxiable.sol
@@ -1,0 +1,41 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+
+/**
+ * @title Proxiable
+ * @dev Contracts that are meant to be upgradable must inherit from this contract
+ */
+contract Proxiable {
+    bool internal _initialized;
+
+    event Upgraded(address indexed implementation);
+
+    function proxiableUUID() public pure returns (bytes32) {
+        return 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7;
+    }
+
+    /**
+     * @notice Checks if the contract is initialized
+     * @return Init status
+     */
+    function isInitialized() public view returns(bool) {
+        return _initialized;
+    }
+
+    /**
+     * @dev Update code logic
+     * @param newAddress address where the contract logic is located at
+     */
+    function updateCodeAddress(address newAddress) internal {
+        // Code position in storage is keccak256("PROXIABLE") = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
+        require(
+            bytes32(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7) == Proxiable(newAddress).proxiableUUID(),
+            "Not compatible"
+        );
+        assembly { // solium-disable-line
+            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, newAddress)
+        }
+        emit Upgraded(newAddress);
+    }
+
+}

--- a/dapps/tests/teller-contracts/contracts/proxy/Proxy.sol
+++ b/dapps/tests/teller-contracts/contracts/proxy/Proxy.sol
@@ -1,0 +1,70 @@
+/* solium-disable security/no-block-members */
+/* solium-disable security/no-inline-assembly */
+
+pragma solidity >=0.5.0 <0.6.0;
+
+
+/**
+ * @title Proxy
+ * @dev EIP1822
+ */
+contract Proxy {
+    /**
+     * @param constructData Constructor input data for initializing the proxy
+     * @param contractLogic Address of the contract used as implementation logic for the proxy
+     */
+    constructor(bytes memory constructData, address contractLogic) public {
+        // save the code address
+        assembly { // solium-disable-line
+            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, contractLogic)
+        }
+
+        if (constructData.length == 0) {
+            return;
+        }
+
+        (bool success, bytes memory _) = contractLogic.delegatecall(constructData); // solium-disable-line
+        require(success, "Construction failed");
+    }
+
+    /**
+     * @dev Fallback function allowing to perform a delegatecall to the given implementation.
+     * This function will return whatever the implementation call returns
+     */
+    function() external payable {
+        assembly { // solium-disable-line
+            let contractLogic := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+            calldatacopy(0x0, 0x0, calldatasize)
+            let success := delegatecall(sub(gas, 10000), contractLogic, 0x0, calldatasize, 0, 0)
+            let retSz := returndatasize
+            returndatacopy(0, 0, retSz)
+            switch success
+            case 0 {
+                revert(0, retSz)
+            }
+            default {
+                return(0, retSz)
+            }
+        }
+    }
+
+    /**
+     * @dev Tells the address of the implementation where every call will be delegated.
+     * @return address of the implementation to which it will be delegated
+     */
+    function implementation() public view returns (address) {
+        address contractLogic;
+        assembly { // solium-disable-line
+           contractLogic := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+        }
+        return contractLogic;
+    }
+
+    /**
+     * @dev EIP897 proxy type
+     * @return 1 to indicate not upgradable proxy
+     */
+    function proxyType() public pure returns (uint256) {
+        return 1;
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/Arbitrable.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/Arbitrable.sol
@@ -1,0 +1,171 @@
+/* solium-disable security/no-block-members */
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./ArbitrationLicense.sol";
+
+
+/**
+ * Arbitrable
+ * @dev Utils for management of disputes
+ */
+contract Arbitrable {
+
+    enum ArbitrationResult {UNSOLVED, BUYER, SELLER}
+    enum ArbitrationMotive {NONE, UNRESPONSIVE, PAYMENT_ISSUE, OTHER}
+
+
+    ArbitrationLicense public arbitratorLicenses;
+
+    mapping(uint => ArbitrationCase) public arbitrationCases;
+
+    address public fallbackArbitrator;
+
+    uint public arbitrationTimeout;
+
+    struct ArbitrationCase {
+        bool open;
+        address openBy;
+        address arbitrator;
+        uint arbitratorTimeout;
+        ArbitrationResult result;
+        ArbitrationMotive motive;
+    }
+
+    event ArbitratorChanged(uint indexed escrowId, address sender, address indexed ogArbitrator, address indexed newArbitrator);
+    event ArbitrationCanceled(uint indexed escrowId);
+    event ArbitrationRequired(uint indexed escrowId, uint timeout, address indexed arbitrator);
+    event ArbitrationResolved(uint indexed escrowId, ArbitrationResult result, address indexed arbitrator);
+
+    /**
+     * @param _arbitratorLicenses Address of the Arbitrator Licenses contract
+     * @param _fallbackArbitrator Address of the fallback arbitrator in case the original arbitrator does not work on a dispute
+     */
+    constructor(address _arbitratorLicenses, address _fallbackArbitrator) public {
+        arbitratorLicenses = ArbitrationLicense(_arbitratorLicenses);
+        fallbackArbitrator = _fallbackArbitrator;
+        arbitrationTimeout = 5 days;
+    }
+
+    /**
+     * @param _escrowId Id of the escrow with an open dispute
+     * @param _releaseFunds Release funds to the buyer
+     * @param _arbitrator Address of the arbitrator solving the dispute
+     * @dev Abstract contract used to perform actions after a dispute has been settled
+     */
+    function _solveDispute(uint _escrowId, bool _releaseFunds, address _arbitrator) internal;
+
+    /**
+     * @notice Get arbitrator of an escrow
+     * @return address Arbitrator address
+     */
+    function _getArbitrator(uint _escrowId) internal view returns(address);
+
+    /**
+     * @notice Determine if a dispute exists/existed for an escrow
+     * @param _escrowId Escrow to verify
+     * @return bool result
+     */
+    function isDisputed(uint _escrowId) public view returns (bool) {
+        return _isDisputed(_escrowId);
+    }
+
+    function _isDisputed(uint _escrowId) internal view returns (bool) {
+        return arbitrationCases[_escrowId].open || arbitrationCases[_escrowId].result != ArbitrationResult.UNSOLVED;
+    }
+
+    /**
+     * @notice Determine if a dispute existed for an escrow
+     * @param _escrowId Escrow to verify
+     * @return bool result
+     */
+    function hadDispute(uint _escrowId) public view returns (bool) {
+        return arbitrationCases[_escrowId].result != ArbitrationResult.UNSOLVED;
+    }
+
+    /**
+     * @notice Cancel arbitration
+     * @param _escrowId Escrow to cancel
+     */
+    function cancelArbitration(uint _escrowId) external {
+        require(arbitrationCases[_escrowId].openBy == msg.sender, "Arbitration can only be canceled by the opener");
+        require(arbitrationCases[_escrowId].result == ArbitrationResult.UNSOLVED && arbitrationCases[_escrowId].open, 
+            "Arbitration already solved or not open");
+
+        delete arbitrationCases[_escrowId];
+
+        emit ArbitrationCanceled(_escrowId);
+    }
+
+    /**
+     * @notice Opens a dispute between a seller and a buyer
+     * @param _escrowId Id of the Escrow that is being disputed
+     * @param _openBy Address of the person opening the dispute (buyer or seller)
+     * @param _motive Description of the problem
+     */
+    function _openDispute(uint _escrowId, address _openBy, uint8 _motive) internal {
+        require(arbitrationCases[_escrowId].result == ArbitrationResult.UNSOLVED && !arbitrationCases[_escrowId].open,
+                "Arbitration already solved or has been opened before");
+
+        address arbitratorAddress = _getArbitrator(_escrowId);
+
+        require(arbitratorAddress != address(0), "Arbitrator is required");
+
+        uint timeout = block.timestamp + arbitrationTimeout;
+
+        arbitrationCases[_escrowId] = ArbitrationCase({
+            open: true,
+            openBy: _openBy,
+            arbitrator: arbitratorAddress,
+            arbitratorTimeout: timeout,
+            result: ArbitrationResult.UNSOLVED,
+            motive: ArbitrationMotive(_motive)
+        });
+
+        emit ArbitrationRequired(_escrowId, timeout, arbitratorAddress);
+    }
+
+    /**
+     * @notice Allow participants to escalate dispute to fallback arbitrator after timeout
+     * @param _escrowId Id of the Escrow that is being disputed
+     */
+    function escalateDispute(uint _escrowId) external {
+        require(arbitrationCases[_escrowId].open && arbitrationCases[_escrowId].result == ArbitrationResult.UNSOLVED, "Case must be open and unsolved");
+        require(block.timestamp > arbitrationCases[_escrowId].arbitratorTimeout, "Arbitration is still active");
+
+        emit ArbitratorChanged(_escrowId, msg.sender, arbitrationCases[_escrowId].arbitrator, fallbackArbitrator);
+        arbitrationCases[_escrowId].arbitrator = fallbackArbitrator;
+    }
+
+    /**
+     * @notice Set arbitration result in favour of the buyer or seller and transfer funds accordingly
+     * @param _escrowId Id of the escrow
+     * @param _result Result of the arbitration
+     */
+    function setArbitrationResult(uint _escrowId, ArbitrationResult _result) external {
+        require(arbitrationCases[_escrowId].open && arbitrationCases[_escrowId].result == ArbitrationResult.UNSOLVED,
+                "Case must be open and unsolved");
+        require(_result != ArbitrationResult.UNSOLVED, "Arbitration does not have result");
+
+        if (msg.sender == fallbackArbitrator) {
+            require(block.timestamp > arbitrationCases[_escrowId].arbitratorTimeout, "Arbitration is still active");
+            if (arbitrationCases[_escrowId].arbitrator != msg.sender) {
+                emit ArbitratorChanged(_escrowId, msg.sender, arbitrationCases[_escrowId].arbitrator, msg.sender);
+                arbitrationCases[_escrowId].arbitrator = msg.sender;
+            }
+        } else {
+            require(arbitratorLicenses.isLicenseOwner(msg.sender), "Only arbitrators can invoke this function");
+            require(arbitrationCases[_escrowId].arbitrator == msg.sender, "Invalid escrow arbitrator");
+        }
+
+        arbitrationCases[_escrowId].open = false;
+        arbitrationCases[_escrowId].result = _result;
+
+        emit ArbitrationResolved(_escrowId, _result, msg.sender);
+
+        if (_result == ArbitrationResult.BUYER) {
+            _solveDispute(_escrowId, true, msg.sender);
+        } else {
+            _solveDispute(_escrowId, false, msg.sender);
+        }
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/ArbitrationLicense.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/ArbitrationLicense.sol
@@ -1,0 +1,230 @@
+/* solium-disable security/no-block-members */
+pragma solidity ^0.5.8;
+
+import "./License.sol";
+
+/**
+* @title ArbitratorLicense
+* @dev Contract for management of an arbitrator license
+*/
+contract ArbitrationLicense is License {
+
+    enum RequestStatus {NONE,AWAIT,ACCEPTED,REJECTED,CLOSED}
+
+    struct Request{
+        address seller;
+        address arbitrator;
+        RequestStatus status;
+        uint date;
+    }
+
+	struct ArbitratorLicenseDetails {
+        uint id;
+        bool acceptAny;// accept any seller
+    }
+
+    mapping(address => ArbitratorLicenseDetails) public arbitratorlicenseDetails;
+    mapping(address => mapping(address => bool)) public permissions;
+    mapping(address => mapping(address => bool)) public blacklist;
+    mapping(bytes32 => Request) public requests;
+
+    event ArbitratorRequested(bytes32 id, address indexed seller, address indexed arbitrator);
+
+    event RequestAccepted(bytes32 id, address indexed arbitrator, address indexed seller);
+    event RequestRejected(bytes32 id, address indexed arbitrator, address indexed seller);
+    event RequestCanceled(bytes32 id, address indexed arbitrator, address indexed seller);
+    event BlacklistSeller(address indexed arbitrator, address indexed seller);
+    event UnBlacklistSeller(address indexed arbitrator, address indexed seller);
+
+    /**
+     * @param _tokenAddress Address of token used to pay for licenses (SNT)
+     * @param _price Amount of token needed to buy a license
+     * @param _burnAddress Burn address where the price of the license is sent
+     */
+    constructor(address _tokenAddress, uint256 _price, address _burnAddress)
+      License(_tokenAddress, _price, _burnAddress)
+      public {}
+
+    /**
+     * @notice Buy an arbitrator license
+     */
+    function buy() external returns(uint) {
+        return _buy(msg.sender, false);
+    }
+
+    /**
+     * @notice Buy an arbitrator license and set if the arbitrator accepts any seller
+     * @param _acceptAny When set to true, all sellers are accepted by the arbitrator
+     */
+    function buy(bool _acceptAny) external returns(uint) {
+        return _buy(msg.sender, _acceptAny);
+    }
+
+    /**
+     * @notice Buy an arbitrator license and set if the arbitrator accepts any seller. Sets the arbitrator as the address in params instead of the sender
+     * @param _sender Address of the arbitrator
+     * @param _acceptAny When set to true, all sellers are accepted by the arbitrator
+     */
+    function _buy(address _sender, bool _acceptAny) internal returns (uint id) {
+        id = _buyFrom(_sender);
+        arbitratorlicenseDetails[_sender].id = id;
+        arbitratorlicenseDetails[_sender].acceptAny = _acceptAny;
+    }
+
+    /**
+     * @notice Change acceptAny parameter for arbitrator
+     * @param _acceptAny indicates does arbitrator allow to accept any seller/choose sellers
+     */
+    function changeAcceptAny(bool _acceptAny) public {
+        require(isLicenseOwner(msg.sender), "Message sender should have a valid arbitrator license");
+        require(arbitratorlicenseDetails[msg.sender].acceptAny != _acceptAny,
+                "Message sender should pass parameter different from the current one");
+
+        arbitratorlicenseDetails[msg.sender].acceptAny = _acceptAny;
+    }
+
+    /**
+     * @notice Allows arbitrator to accept a seller
+     * @param _arbitrator address of a licensed arbitrator
+     */
+    function requestArbitrator(address _arbitrator) public {
+       require(isLicenseOwner(_arbitrator), "Arbitrator should have a valid license");
+       require(!arbitratorlicenseDetails[_arbitrator].acceptAny, "Arbitrator already accepts all cases");
+
+       bytes32 _id = keccak256(abi.encodePacked(_arbitrator, msg.sender));
+       RequestStatus _status = requests[_id].status;
+       require(_status != RequestStatus.AWAIT && _status != RequestStatus.ACCEPTED, "Invalid request status");
+
+       if(_status == RequestStatus.REJECTED || _status == RequestStatus.CLOSED){
+           require(requests[_id].date + 3 days < block.timestamp,
+            "Must wait 3 days before requesting the arbitrator again");
+       }
+
+       requests[_id] = Request({
+            seller: msg.sender,
+            arbitrator: _arbitrator,
+            status: RequestStatus.AWAIT,
+            date: block.timestamp
+       });
+
+       emit ArbitratorRequested(_id, msg.sender, _arbitrator);
+    }
+
+    /**
+     * @dev Get Request Id
+     * @param _arbitrator Arbitrator address
+     * @param _account Seller account
+     * @return Request Id
+     */
+    function getId(address _arbitrator, address _account) external pure returns(bytes32){
+        return keccak256(abi.encodePacked(_arbitrator,_account));
+    }
+
+    /**
+     * @notice Allows arbitrator to accept a seller's request
+     * @param _id request id
+     */
+    function acceptRequest(bytes32 _id) public {
+        require(isLicenseOwner(msg.sender), "Arbitrator should have a valid license");
+        require(requests[_id].status == RequestStatus.AWAIT, "This request is not pending");
+        require(!arbitratorlicenseDetails[msg.sender].acceptAny, "Arbitrator already accepts all cases");
+        require(requests[_id].arbitrator == msg.sender, "Invalid arbitrator");
+
+        requests[_id].status = RequestStatus.ACCEPTED;
+
+        address _seller = requests[_id].seller;
+        permissions[msg.sender][_seller] = true;
+
+        emit RequestAccepted(_id, msg.sender, requests[_id].seller);
+    }
+
+    /**
+     * @notice Allows arbitrator to reject a request
+     * @param _id request id
+     */
+    function rejectRequest(bytes32 _id) public {
+        require(isLicenseOwner(msg.sender), "Arbitrator should have a valid license");
+        require(requests[_id].status == RequestStatus.AWAIT || requests[_id].status == RequestStatus.ACCEPTED,
+            "Invalid request status");
+        require(!arbitratorlicenseDetails[msg.sender].acceptAny, "Arbitrator accepts all cases");
+        require(requests[_id].arbitrator == msg.sender, "Invalid arbitrator");
+
+        requests[_id].status = RequestStatus.REJECTED;
+        requests[_id].date = block.timestamp;
+
+        address _seller = requests[_id].seller;
+        permissions[msg.sender][_seller] = false;
+
+        emit RequestRejected(_id, msg.sender, requests[_id].seller);
+    }
+
+    /**
+     * @notice Allows seller to cancel a request
+     * @param _id request id
+     */
+    function cancelRequest(bytes32 _id) public {
+        require(requests[_id].seller == msg.sender,  "This request id does not belong to the message sender");
+        require(requests[_id].status == RequestStatus.AWAIT || requests[_id].status == RequestStatus.ACCEPTED, "Invalid request status");
+
+        address arbitrator = requests[_id].arbitrator;
+
+        requests[_id].status = RequestStatus.CLOSED;
+        requests[_id].date = block.timestamp;
+
+        address _arbitrator = requests[_id].arbitrator;
+        permissions[_arbitrator][msg.sender] = false;
+
+        emit RequestCanceled(_id, arbitrator, requests[_id].seller);
+    }
+
+    /**
+     * @notice Allows arbitrator to blacklist a seller
+     * @param _seller Seller address
+     */
+    function blacklistSeller(address _seller) public {
+        require(isLicenseOwner(msg.sender), "Arbitrator should have a valid license");
+
+        blacklist[msg.sender][_seller] = true;
+
+        emit BlacklistSeller(msg.sender, _seller);
+    }
+
+    /**
+     * @notice Allows arbitrator to remove a seller from the blacklist
+     * @param _seller Seller address
+     */
+    function unBlacklistSeller(address _seller) public {
+        require(isLicenseOwner(msg.sender), "Arbitrator should have a valid license");
+
+        blacklist[msg.sender][_seller] = false;
+
+        emit UnBlacklistSeller(msg.sender, _seller);
+    }
+
+    /**
+     * @notice Checks if Arbitrator permits to use his/her services
+     * @param _seller sellers's address
+     * @param _arbitrator arbitrator's address
+     */
+    function isAllowed(address _seller, address _arbitrator) public view returns(bool) {
+        return (arbitratorlicenseDetails[_arbitrator].acceptAny && !blacklist[_arbitrator][_seller]) || permissions[_arbitrator][_seller];
+    }
+
+    /**
+     * @notice Support for "approveAndCall". Callable only by `token()`.
+     * @param _from Who approved.
+     * @param _amount Amount being approved, need to be equal `price()`.
+     * @param _token Token being approved, need to be equal `token()`.
+     * @param _data Abi encoded data with selector of `buy(and)`.
+     */
+    function receiveApproval(address _from, uint256 _amount, address _token, bytes memory _data) public {
+        require(_amount == price, "Wrong value");
+        require(_token == address(token), "Wrong token");
+        require(_token == address(msg.sender), "Wrong call");
+        require(_data.length == 4, "Wrong data length");
+
+        require(_abiDecodeBuy(_data) == bytes4(0xa6f2ae3a), "Wrong method selector"); //bytes4(keccak256("buy()"))
+
+        _buy(_from, false);
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/Escrow.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/Escrow.sol
@@ -1,0 +1,749 @@
+ /* solium-disable security/no-block-members */
+/* solium-disable security/no-inline-assembly */
+
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../common/Pausable.sol";
+import "../common/MessageSigned.sol";
+import "../token/ERC20Token.sol";
+import "../token/SafeTransfer.sol";
+import "./ArbitrationLicense.sol";
+import "./License.sol";
+import "./UserStore.sol";
+import "./OfferStore.sol";
+import "./Fees.sol";
+import "./Arbitrable.sol";
+import "./IEscrow.sol";
+import "../proxy/Proxiable.sol";
+
+/**
+ * @title Escrow
+ * @dev Escrow contract for selling ETH and ERC20 tokens
+ */
+contract Escrow is IEscrow, Pausable, MessageSigned, Fees, Arbitrable, Proxiable {
+
+    EscrowTransaction[] public transactions;
+
+    address public relayer;
+    OfferStore public offerStore;
+    UserStore public userStore;
+
+
+    event Created(uint indexed offerId, address indexed seller, address indexed buyer, uint escrowId);
+    event Funded(uint indexed escrowId, address indexed buyer, uint expirationTime, uint amount);
+    event Paid(uint indexed escrowId, address indexed seller);
+    event Released(uint indexed escrowId, address indexed seller, address indexed buyer, address destination, bool isDispute);
+    event Canceled(uint indexed escrowId, address indexed seller, address indexed buyer, bool isDispute);
+    event DestinationUpdated(uint indexed escrowId, address indexed buyer, address newAddress);
+    event Rating(uint indexed offerId, address indexed participant, uint indexed escrowId, uint rating, bool ratingSeller);
+
+    /**
+     * @param _relayer EscrowRelay contract address
+     * @param _fallbackArbitrator Default arbitrator to use after timeout on solving arbitrations
+     * @param _arbitratorLicenses License contract instance address for arbitrators
+     * @param _offerStore OfferStore contract address
+     * @param _userStore UserStore contract address
+     * @param _feeDestination Address where the fees are going to be sent
+     * @param _feeMilliPercent Percentage applied as a fee to each escrow. 1000 == 1%
+     */
+    constructor(
+        address _relayer,
+        address _fallbackArbitrator,
+        address _arbitratorLicenses,
+        address _offerStore,
+        address _userStore,
+        address payable _feeDestination,
+        uint _feeMilliPercent)
+        Fees(_feeDestination, _feeMilliPercent)
+        Arbitrable(_arbitratorLicenses, _fallbackArbitrator)
+        public {
+        _initialized = true;
+        relayer = _relayer;
+        offerStore = OfferStore(_offerStore);
+        userStore = UserStore(_userStore);
+    }
+
+    /**
+     * @dev Initialize contract (used with proxy). Can only be called once
+     * @param _fallbackArbitrator Default arbitrator to use after timeout on solving arbitrations
+     * @param _relayer EscrowRelay contract address
+     * @param _arbitratorLicenses License contract instance address for arbitrators
+     * @param _offerStore OfferStore contract address
+     * @param _userStore UserStore contract address
+     * @param _feeDestination Address where the fees are going to be sent
+     * @param _feeMilliPercent Percentage applied as a fee to each escrow. 1000 == 1%
+     */
+    function init(
+        address _fallbackArbitrator,
+        address _relayer,
+        address _arbitratorLicenses,
+        address _offerStore,
+        address _userStore,
+        address payable _feeDestination,
+        uint _feeMilliPercent
+    ) external {
+        assert(_initialized == false);
+
+        _initialized = true;
+
+        fallbackArbitrator = _fallbackArbitrator;
+        arbitratorLicenses = ArbitrationLicense(_arbitratorLicenses);
+        offerStore = OfferStore(_offerStore);
+        userStore = UserStore(_userStore);
+        relayer = _relayer;
+        feeDestination = _feeDestination;
+        feeMilliPercent = _feeMilliPercent;
+        paused = false;
+        arbitrationTimeout = 5 days;
+
+        _setOwner(msg.sender);
+    }
+    
+    /**
+     * @dev Update arbitration timeout. Can only be called by owner
+     * @param _newTimeout new timeout in seconds
+     */
+    function setArbitrationTimeout(uint _newTimeout) public onlyOwner {
+        arbitrationTimeout = _newTimeout;
+    }
+
+    /**
+     * @dev Update proxy implementation. Can only be called by owner
+     * @param _newCode New contract implementation address
+     */
+    function updateCode(address _newCode) public onlyOwner {
+        updateCodeAddress(_newCode);
+    }
+
+    /**
+     * @dev Update relayer contract address. Can only be called by the contract owner
+     * @param _relayer EscrowRelay contract address
+     */
+    function setRelayer(address _relayer) external onlyOwner {
+        relayer = _relayer;
+    }
+
+    /**
+     * @dev Update fallback arbitrator. Can only be called by the contract owner
+     * @param _fallbackArbitrator New fallback arbitrator
+     */
+    function setFallbackArbitrator(address _fallbackArbitrator) external onlyOwner {
+        fallbackArbitrator = _fallbackArbitrator;
+    }
+
+    /**
+     * @dev Update license contract addresses
+     * @param _arbitratorLicenses License contract instance address for arbitrators
+     */
+    function setArbitratorLicense(address _arbitratorLicenses) external onlyOwner {
+        arbitratorLicenses = ArbitrationLicense(_arbitratorLicenses);
+    }
+
+    /**
+     * @dev Update Metadata Stores contract address
+     * @param _offerStore OfferStore contract address
+     * @param _userStore UserStore contract address
+     */
+    function setMetadataStore(address _offerStore, address _userStore) external onlyOwner {
+        offerStore = OfferStore(_offerStore);
+        userStore = UserStore(_userStore);
+    }
+
+    /**
+     * @dev Escrow creation logic. Requires contract to be unpaused
+     * @param _buyer Buyer Address
+     * @param _destination Address that will receive the crypto
+     * @param _offerId Offer
+     * @param _tokenAmount Amount buyer is willing to trade
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
+     * @return Id of the Escrow
+     */
+    function _createTransaction(
+        address payable _buyer,
+        address payable _destination,
+        uint _offerId,
+        uint _tokenAmount,
+        uint _fiatAmount
+    ) internal whenNotPaused returns(uint escrowId)
+    {
+        address payable seller;
+        address payable arbitrator;
+        bool deleted;
+        address token;
+
+        (token, , , , , , seller, arbitrator, deleted) = offerStore.offer(_offerId);
+
+        require(!deleted, "Offer is not valid");
+        require(seller != _buyer, "Seller and Buyer must be different");
+        require(arbitrator != _buyer && arbitrator != address(0), "Cannot buy offers where buyer is arbitrator");
+        require(_tokenAmount != 0 && _fiatAmount != 0, "Trade amounts cannot be 0");
+
+        escrowId = transactions.length++;
+
+        EscrowTransaction storage trx = transactions[escrowId];
+
+        trx.offerId = _offerId;
+        trx.token = token;
+        trx.buyer = _buyer;
+        trx.seller = seller;
+        trx.destination = _destination;
+        trx.arbitrator = arbitrator;
+        trx.tokenAmount = _tokenAmount;
+        trx.fiatAmount = _fiatAmount;
+
+        emit Created(
+            _offerId,
+            seller,
+            _buyer,
+            escrowId
+        );
+    }
+
+    /**
+     * @notice Create a new escrow
+     * @param _offerId Offer
+     * @param _tokenAmount Amount buyer is willing to trade
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
+     * @param _destination Address that will receive the crypto
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _location The location on earth
+     * @param _username The username of the user
+     * @return Id of the new escrow
+     * @dev Requires contract to be unpaused.
+     */
+    function createEscrow(
+        uint _offerId,
+        uint _tokenAmount,
+        uint _fiatAmount,
+        address payable _destination,
+        string memory _contactData,
+        string memory _location,
+        string memory _username
+    ) public returns(uint escrowId) {
+        userStore.addOrUpdateUser(msg.sender, _contactData, _location, _username);
+        escrowId = _createTransaction(msg.sender, _destination, _offerId, _tokenAmount, _fiatAmount);
+    }
+
+    /**
+     * @notice Create a new escrow
+     * @param _offerId Offer
+     * @param _tokenAmount Amount buyer is willing to trade
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
+     * @param _destination Address that will receive the crypto
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _username The username of the user
+     * @param _nonce The nonce for the user (from UserStore.user_nonce(address))
+     * @param _signature buyer's signature
+     * @return Id of the new escrow
+     * @dev Requires contract to be unpaused.
+     *      The seller needs to be licensed.
+     */
+    function createEscrow(
+        uint _offerId,
+        uint _tokenAmount,
+        uint _fiatAmount,
+        address payable _destination,
+        string memory _contactData,
+        string memory _location,
+        string memory _username,
+        uint _nonce,
+        bytes memory _signature
+    ) public returns(uint escrowId) {
+        address payable _buyer = userStore.addOrUpdateUser(_signature, _contactData, _location, _username, _nonce);
+        escrowId = _createTransaction(_buyer, _destination, _offerId, _tokenAmount, _fiatAmount);
+    }
+
+   /**
+     * @dev Relay function for creating a transaction
+     *      Can only be called by relayer address
+     * @param _sender Address marking the transaction as paid
+     * @param _offerId Offer
+     * @param _tokenAmount Amount buyer is willing to trade
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
+     * @param _destination Address that will receive the crypto
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _location The location on earth
+     * @param _username The username of the user
+     * @return Id of the new escrow
+     * @dev Requires contract to be unpaused.
+     *      The seller needs to be licensed.
+     */
+    function createEscrow_relayed(
+        address payable _sender,
+        uint _offerId,
+        uint _tokenAmount,
+        uint _fiatAmount,
+        address payable _destination,
+        string calldata _contactData,
+        string calldata _location,
+        string calldata _username
+    ) external returns(uint escrowId) {
+        assert(msg.sender == relayer);
+
+        userStore.addOrUpdateUser(_sender, _contactData, _location, _username);
+        escrowId = _createTransaction(_sender, _destination,  _offerId, _tokenAmount, _fiatAmount);
+    }
+
+    function updateDestination(uint _escrowId, address payable _destination) external whenNotPaused {
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        EscrowStatus mStatus = trx.status;
+        require(mStatus == EscrowStatus.FUNDED || mStatus == EscrowStatus.CREATED || mStatus == EscrowStatus.PAID,
+                "Only transactions in created, funded or paid state can have their destination updated");
+
+        require(trx.buyer == msg.sender, "Only the buyer can invoke this function");
+
+        trx.destination = _destination;
+
+        emit DestinationUpdated(_escrowId, trx.buyer, _destination);
+    }
+
+    /**
+     * @notice Fund a new escrow
+     * @param _escrowId Id of the escrow
+     * @dev Requires contract to be unpaused.
+     *      The expiration time must be at least 10min in the future
+     *      For eth transfer, _amount must be equals to msg.value, for token transfer, requires an allowance and transfer valid for _amount
+     */
+    function fund(uint _escrowId) external payable whenNotPaused {
+        _fund(msg.sender, _escrowId);
+    }
+
+    /**
+     * @dev Escrow funding logic
+     * @param _from Seller address
+     * @param _escrowId Id of the escrow
+     * @dev Requires contract to be unpaused.
+     *      The expiration time must be at least 10min in the future
+     *      For eth transfer, _amount must be equals to msg.value, for token transfer, requires an allowance and transfer valid for _amount
+     */
+    function _fund(address _from, uint _escrowId) internal whenNotPaused {
+        require(transactions[_escrowId].seller == _from, "Only the seller can invoke this function");
+        require(transactions[_escrowId].status == EscrowStatus.CREATED, "Invalid escrow status");
+
+        transactions[_escrowId].expirationTime = block.timestamp + 5 days;
+        transactions[_escrowId].status = EscrowStatus.FUNDED;
+
+        uint tokenAmount = transactions[_escrowId].tokenAmount;
+
+        address token = transactions[_escrowId].token;
+
+        _payFee(_from, _escrowId, tokenAmount, token);
+
+        emit Funded(_escrowId, transactions[_escrowId].buyer, block.timestamp + 5 days, tokenAmount);
+    }
+
+    /**
+     * @notice Create and fund a new escrow, as a seller, once you get a buyer signature
+     * @param _offerId Offer
+     * @param _tokenAmount Amount buyer is willing to trade
+     * @param _fiatAmount Indicates how much FIAT will the user pay for the tokenAmount
+     * @param _bContactData Contact Data   ContactType:UserId
+     * @param _bLocation The location on earth
+     * @param _bUsername The username of the user
+     * @param _bNonce The nonce for the user (from userStore.user_nonce(address))
+     * @param _bSignature buyer's signature
+     * @return Id of the new escrow
+     * @dev Requires contract to be unpaused.
+     *      Restrictions from escrow creation and funding applies
+     */
+    function createAndFund (
+        uint _offerId,
+        uint _tokenAmount,
+        uint _fiatAmount,
+        string memory _bContactData,
+        string memory _bLocation,
+        string memory _bUsername,
+        uint _bNonce,
+        bytes memory _bSignature
+    ) public payable returns(uint escrowId) {
+        address payable _buyer = userStore.addOrUpdateUser(_bSignature, _bContactData, _bLocation, _bUsername, _bNonce);
+        escrowId = _createTransaction(_buyer, _buyer, _offerId, _tokenAmount, _fiatAmount);
+        _fund(msg.sender, escrowId);
+    }
+
+    /**
+     * @dev Buyer marks transaction as paid
+     * @param _sender Address marking the transaction as paid
+     * @param _escrowId Id of the escrow
+     */
+    function _pay(address _sender, uint _escrowId) internal {
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        require(trx.status == EscrowStatus.FUNDED, "Transaction is not funded");
+        require(trx.expirationTime > block.timestamp, "Transaction already expired");
+        require(trx.buyer == _sender, "Only the buyer can invoke this function");
+
+        trx.status = EscrowStatus.PAID;
+
+        emit Paid(_escrowId, trx.seller);
+    }
+
+    /**
+     * @notice Mark transaction as paid
+     * @param _escrowId Id of the escrow
+     * @dev Can only be executed by the buyer
+     */
+    function pay(uint _escrowId) external {
+        _pay(msg.sender, _escrowId);
+    }
+
+    /**
+     * @dev Relay function for marking a transaction as paid
+     *      Can only be called by relayer address
+     * @param _sender Address marking the transaction as paid
+     * @param _escrowId Id of the escrow
+     */
+    function pay_relayed(address _sender, uint _escrowId) external {
+        assert(msg.sender == relayer);
+        _pay(_sender, _escrowId);
+    }
+
+    /**
+     * @notice Obtain message hash to be signed for marking a transaction as paid
+     * @param _escrowId Id of the escrow
+     * @return message hash
+     * @dev Once message is signed, pass it as _signature of pay(uint256,bytes)
+     */
+    function paySignHash(uint _escrowId) public view returns(bytes32){
+        uint256 cid;
+        assembly { 
+		    cid := chainid()
+		}
+        return keccak256(
+            abi.encodePacked(
+                address(this),
+                "pay(uint256)",
+                _escrowId,
+                cid
+            )
+        );
+    }
+
+    /**
+     * @notice Mark transaction as paid (via signed message)
+     * @param _escrowId Id of the escrow
+     * @param _signature Signature of the paySignHash result.
+     * @dev There's a high probability of buyers not having ether to pay for the transaction.
+     *      This allows anyone to relay the transaction.
+     *      TODO: consider deducting funds later on release to pay the relayer (?)
+     */
+    function pay(uint _escrowId, bytes calldata _signature) external {
+        address sender = _recoverAddress(_getSignHash(paySignHash(_escrowId)), _signature);
+        _pay(sender, _escrowId);
+    }
+
+    /**
+     * @dev Release funds to buyer
+     * @param _escrowId Id of the escrow
+     * @param _trx EscrowTransaction with data of transaction to be released
+     * @param _isDispute indicates if the release happened due to a dispute
+     */
+    function _release(uint _escrowId, EscrowTransaction storage _trx, bool _isDispute) internal {
+        require(_trx.status != EscrowStatus.RELEASED, "Already released");
+        _trx.status = EscrowStatus.RELEASED;
+
+        if(!_isDispute){
+            offerStore.refundStake(_trx.offerId);
+        }
+
+        address token = _trx.token;
+        if(token == address(0)){
+            (bool success, ) = _trx.destination.call.value(_trx.tokenAmount)("");
+            require(success, "Transfer failed.");
+        } else {
+            require(_safeTransfer(ERC20Token(token), _trx.destination, _trx.tokenAmount), "Couldn't transfer funds");
+        }
+
+        _releaseFee(_trx.arbitrator, _trx.tokenAmount, token, _isDispute);
+
+        emit Released(_escrowId, _trx.seller, _trx.buyer, _trx.destination, _isDispute);
+    }
+
+    /**
+     * @notice Release escrow funds to buyer
+     * @param _escrowId Id of the escrow
+     * @dev Requires contract to be unpaused.
+     *      Can only be executed by the seller
+     *      Transaction must not be expired, or previously canceled or released
+     */
+    function release(uint _escrowId) external {
+        EscrowStatus mStatus = transactions[_escrowId].status;
+        require(transactions[_escrowId].seller == msg.sender, "Only the seller can invoke this function");
+        require(mStatus == EscrowStatus.PAID || mStatus == EscrowStatus.FUNDED, "Invalid transaction status");
+        require(!_isDisputed(_escrowId), "Can't release a transaction that has an arbitration process");
+        _release(_escrowId, transactions[_escrowId], false);
+    }
+
+    /**
+     * @dev Cancel an escrow operation
+     * @param _escrowId Id of the escrow
+     * @notice Requires contract to be unpaused.
+     *         Can only be executed by the seller
+     *         Transaction must be expired, or previously canceled or released
+     */
+    function cancel(uint _escrowId) external whenNotPaused {
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        EscrowStatus mStatus = trx.status;
+        require(mStatus == EscrowStatus.FUNDED || mStatus == EscrowStatus.CREATED,
+                "Only transactions in created or funded state can be canceled");
+
+        require(trx.buyer == msg.sender || trx.seller == msg.sender, "Only participants can invoke this function");
+
+        if(mStatus == EscrowStatus.FUNDED){
+            if(msg.sender == trx.seller){
+                require(trx.expirationTime < block.timestamp, "Can only be canceled after expiration");
+            }
+        }
+
+        _cancel(_escrowId, trx, false);
+    }
+
+    // Same as cancel, but relayed by a contract so we get the sender as param
+    function cancel_relayed(address _sender, uint _escrowId) external {
+        assert(msg.sender == relayer);
+
+        EscrowTransaction storage trx = transactions[_escrowId];
+        EscrowStatus mStatus = trx.status;
+        require(trx.buyer == _sender, "Only the buyer can invoke this function");
+        require(mStatus == EscrowStatus.FUNDED || mStatus == EscrowStatus.CREATED,
+                "Only transactions in created or funded state can be canceled");
+
+         _cancel(_escrowId, trx, false);
+    }
+
+    /**
+     * @dev Cancel transaction and send funds back to seller
+     * @param _escrowId Id of the escrow
+     * @param trx EscrowTransaction with details of transaction to be marked as canceled
+     */
+    function _cancel(uint _escrowId, EscrowTransaction storage trx, bool isDispute) internal {
+        EscrowStatus origStatus = trx.status;
+
+        require(trx.status != EscrowStatus.CANCELED, "Already canceled");
+
+        trx.status = EscrowStatus.CANCELED;
+
+        if (origStatus == EscrowStatus.FUNDED) {
+            address token = trx.token;
+            uint amount = trx.tokenAmount;
+            if (!isDispute) {
+                amount += _getValueOffMillipercent(trx.tokenAmount, feeMilliPercent);
+            }
+
+            if (token == address(0)) {
+                (bool success, ) = trx.seller.call.value(amount)("");
+                require(success, "Transfer failed.");
+            } else {
+                ERC20Token erc20token = ERC20Token(token);
+                require(_safeTransfer(erc20token, trx.seller, amount), "Transfer failed");
+            }
+        }
+
+        trx.status = EscrowStatus.CANCELED;
+
+        emit Canceled(_escrowId, trx.seller, trx.buyer, isDispute);
+    }
+
+
+    /**
+     * @notice Rates a transaction
+     * @param _escrowId Id of the escrow
+     * @param _rate rating of the transaction from 1 to 5
+     * @dev Can only be executed by the buyer
+     *      Transaction must released
+     */
+    function _rateTransaction(address _sender, uint _escrowId, uint _rate) internal {
+        require(_rate >= 1, "Rating needs to be at least 1");
+        require(_rate <= 5, "Rating needs to be at less than or equal to 5");
+        EscrowTransaction storage trx = transactions[_escrowId];
+        require(trx.status == EscrowStatus.RELEASED || hadDispute(_escrowId), "Transaction not completed yet");
+
+        if (trx.buyer == _sender) {
+            require(trx.sellerRating == 0, "Transaction already rated");
+            emit Rating(trx.offerId, trx.seller, _escrowId, _rate, true);
+            trx.sellerRating = _rate;
+        } else if (trx.seller == _sender) {
+            require(trx.buyerRating == 0, "Transaction already rated");
+            emit Rating(trx.offerId, trx.buyer, _escrowId, _rate, false);
+            trx.buyerRating = _rate;
+        } else {
+            revert("Only participants can invoke this function");
+        }
+    }
+
+    /**
+     * @notice Rates a transaction
+     * @param _escrowId Id of the escrow
+     * @param _rate rating of the transaction from 1 to 5
+     * @dev Can only be executed by the buyer
+     *      Transaction must released
+     */
+    function rateTransaction(uint _escrowId, uint _rate) external {
+        _rateTransaction(msg.sender, _escrowId, _rate);
+    }
+
+    // Same as rateTransaction, but relayed by a contract so we get the sender as param
+    function rateTransaction_relayed(address _sender, uint _escrowId, uint _rate) external {
+        assert(msg.sender == relayer);
+        _rateTransaction(_sender, _escrowId, _rate);
+
+    }
+
+    /**
+     * @notice Returns basic trade informations (buyer address, seller address, token address and token amount)
+     * @param _escrowId Id of the escrow
+     */
+    function getBasicTradeData(uint _escrowId)
+      external
+      view
+      returns(address payable buyer, address payable seller, address token, uint tokenAmount) {
+        buyer = transactions[_escrowId].buyer;
+        seller = transactions[_escrowId].seller;
+        tokenAmount = transactions[_escrowId].tokenAmount;
+        token = transactions[_escrowId].token;
+
+        return (buyer, seller, token, tokenAmount);
+    }
+
+    /**
+     * @notice Open case as a buyer or seller for arbitration
+     * @param _escrowId Id of the escrow
+     * @param _motive Motive for opening the dispute
+     */
+    function openCase(uint _escrowId, uint8 _motive) external {
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        require(!isDisputed(_escrowId), "Case already exist");
+        require(trx.buyer == msg.sender || trx.seller == msg.sender, "Only participants can invoke this function");
+        require(trx.status == EscrowStatus.PAID, "Cases can only be open for paid transactions");
+
+        _openDispute(_escrowId, msg.sender, _motive);
+    }
+
+    /**
+     * @dev Open case via relayer
+     * @param _sender Address initiating the relayed transaction
+     * @param _escrowId Id of the escrow
+     * @param _motive Motive for opening the dispute
+     */
+    function openCase_relayed(address _sender, uint256 _escrowId, uint8 _motive) external {
+        assert(msg.sender == relayer);
+
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        require(!isDisputed(_escrowId), "Case already exist");
+        require(trx.buyer == _sender, "Only the buyer can invoke this function");
+        require(trx.status == EscrowStatus.PAID, "Cases can only be open for paid transactions");
+
+        _openDispute(_escrowId, _sender, _motive);
+    }
+
+    /**
+     * @notice Open case as a buyer or seller for arbitration via a relay account
+     * @param _escrowId Id of the escrow
+     * @param _motive Motive for opening the dispute
+     * @param _signature Signed message result of openCaseSignHash(uint256)
+     * @dev Consider opening a dispute in aragon court.
+     */
+    function openCase(uint _escrowId, uint8 _motive, bytes calldata _signature) external {
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        require(!isDisputed(_escrowId), "Case already exist");
+        require(trx.status == EscrowStatus.PAID, "Cases can only be open for paid transactions");
+
+        address senderAddress = _recoverAddress(_getSignHash(openCaseSignHash(_escrowId, _motive)), _signature);
+
+        require(trx.buyer == senderAddress || trx.seller == senderAddress, "Only participants can invoke this function");
+
+        _openDispute(_escrowId, msg.sender, _motive);
+    }
+
+    /**
+     * @notice Set arbitration result in favour of the buyer or seller and transfer funds accordingly
+     * @param _escrowId Id of the escrow
+     * @param _releaseFunds Release funds to buyer or cancel escrow
+     * @param _arbitrator Arbitrator address
+     */
+    function _solveDispute(uint _escrowId, bool _releaseFunds, address _arbitrator) internal {
+        EscrowTransaction storage trx = transactions[_escrowId];
+
+        require(trx.buyer != _arbitrator && trx.seller != _arbitrator, "Arbitrator cannot be part of transaction");
+
+        if (_releaseFunds) {
+            _release(_escrowId, trx, true);
+        } else {
+            _cancel(_escrowId, trx, true);
+            _releaseFee(trx.arbitrator, trx.tokenAmount, trx.token, true);
+        }
+    }
+
+    /**
+     * @notice Get arbitrator
+     * @param _escrowId Id of the escrow
+     * @return Arbitrator address
+     */
+    function _getArbitrator(uint _escrowId) internal view returns(address) {
+        return transactions[_escrowId].arbitrator;
+    }
+
+    /**
+     * @notice Obtain message hash to be signed for opening a case
+     * @param _escrowId Id of the escrow
+     * @return message hash
+     * @dev Once message is signed, pass it as _signature of openCase(uint256,bytes)
+     */
+    function openCaseSignHash(uint _escrowId, uint8 _motive) public view returns(bytes32){
+        uint256 cid;
+        assembly { 
+		    cid := chainid()
+		}
+        return keccak256(
+            abi.encodePacked(
+                address(this),
+                "openCase(uint256,uint8)",
+                _escrowId,
+                _motive,
+                cid
+            )
+        );
+    }
+
+    /**
+     * @dev Support for "approveAndCall". Callable only by the fee token.
+     * @param _from Who approved.
+     * @param _amount Amount being approved, need to be equal `getPrice()`.
+     * @param _token Token being approved, need to be equal `token()`.
+     * @param _data Abi encoded data with selector of `register(bytes32,address,bytes32,bytes32)`.
+     */
+    function receiveApproval(address _from, uint256 _amount, address _token, bytes memory _data) public {
+        require(_token == address(msg.sender), "Wrong call");
+        require(_data.length == 36, "Wrong data length");
+
+        bytes4 sig;
+        uint256 escrowId;
+
+        (sig, escrowId) = _abiDecodeFundCall(_data);
+
+        if (sig == bytes4(0xca1d209d)){ // fund(uint256)
+            uint tokenAmount = transactions[escrowId].tokenAmount;
+            require(_amount == tokenAmount + _getValueOffMillipercent(tokenAmount, feeMilliPercent), "Invalid amount");
+            _fund(_from, escrowId);
+        } else {
+            revert("Wrong method selector");
+        }
+    }
+
+    /**
+     * @dev Decodes abi encoded data with selector for "fund".
+     * @param _data Abi encoded data.
+     * @return Decoded registry call.
+     */
+    function _abiDecodeFundCall(bytes memory _data) internal pure returns (bytes4 sig, uint256 escrowId) {
+        assembly {
+            sig := mload(add(_data, add(0x20, 0)))
+            escrowId := mload(add(_data, 36))
+        }
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/Fees.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/Fees.sol
@@ -1,0 +1,125 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../token/ERC20Token.sol";
+import "../token/SafeTransfer.sol";
+import "../common/Ownable.sol";
+import "../common/ReentrancyGuard.sol";
+
+/**
+ * @title Fee utilities
+ * @dev Fee registry, payment and withdraw utilities.
+ */
+contract Fees is Ownable, ReentrancyGuard, SafeTransfer {
+    address payable public feeDestination;
+    uint public feeMilliPercent;
+    mapping(address => uint) public feeTokenBalances;
+    mapping(uint => bool) public feePaid;
+
+    event FeeDestinationChanged(address payable);
+    event FeeMilliPercentChanged(uint amount);
+    event FeesWithdrawn(uint amount, address token);
+
+    /**
+     * @param _feeDestination Address to send the fees once withdraw is called
+     * @param _feeMilliPercent Millipercent for the fee off teh amount sold
+     */
+    constructor(address payable _feeDestination, uint _feeMilliPercent) public {
+        feeDestination = _feeDestination;
+        feeMilliPercent = _feeMilliPercent;
+    }
+
+    /**
+     * @dev Set Fee Destination Address.
+     *      Can only be called by the owner of the contract
+     * @param _addr New address
+     */
+    function setFeeDestinationAddress(address payable _addr) external onlyOwner {
+        feeDestination = _addr;
+        emit FeeDestinationChanged(_addr);
+    }
+
+    /**
+     * @dev Set Fee Amount
+     * Can only be called by the owner of the contract
+     * @param _feeMilliPercent New millipercent
+     */
+    function setFeeAmount(uint _feeMilliPercent) external onlyOwner {
+        feeMilliPercent = _feeMilliPercent;
+        emit FeeMilliPercentChanged(_feeMilliPercent);
+    }
+
+    /**
+     * @dev Release fee to fee destination and arbitrator
+     * @param _arbitrator Arbitrator address to transfer fee to
+     * @param _value Value sold in the escrow
+     * @param _isDispute Boolean telling if it was from a dispute. With a dispute, the arbitrator gets more
+    */
+    function _releaseFee(address payable _arbitrator, uint _value, address _tokenAddress, bool _isDispute) internal reentrancyGuard {
+        uint _milliPercentToArbitrator;
+        if (_isDispute) {
+            _milliPercentToArbitrator = 100000; // 100%
+        } else {
+            _milliPercentToArbitrator = 10000; // 10%
+        }
+
+        uint feeAmount = _getValueOffMillipercent(_value, feeMilliPercent);
+        uint arbitratorValue = _getValueOffMillipercent(feeAmount, _milliPercentToArbitrator);
+        uint destinationValue = feeAmount - arbitratorValue;
+
+        if (_tokenAddress != address(0)) {
+            ERC20Token tokenToPay = ERC20Token(_tokenAddress);
+            require(_safeTransfer(tokenToPay, _arbitrator, arbitratorValue), "Unsuccessful token transfer - arbitrator");
+            if (destinationValue > 0) {
+                require(_safeTransfer(tokenToPay, feeDestination, destinationValue), "Unsuccessful token transfer - destination");
+            }
+        } else {
+            // EIP1884 fix
+            (bool success, ) = _arbitrator.call.value(arbitratorValue)("");
+            require(success, "Transfer failed.");
+
+            if (destinationValue > 0) {
+                // EIP1884 fix
+                (bool success, ) = feeDestination.call.value(destinationValue)("");
+                require(success, "Transfer failed.");
+
+            }
+        }
+    }
+
+    /**
+     * @dev Calculate fee of an amount based in milliPercent
+     * @param _value Value to obtain the fee
+     * @param _milliPercent parameter to calculate the fee
+     * @return Fee amount for _value
+     */
+    function _getValueOffMillipercent(uint _value, uint _milliPercent) internal pure returns(uint) {
+        // To get the factor, we divide like 100 like a normal percent, but we multiply that by 1000 because it's a milliPercent
+        // Eg: 1 % = 1000 millipercent => Factor is 0.01, so 1000 divided by 100 * 1000
+        return (_value * _milliPercent) / (100 * 1000);
+    }
+
+    /**
+     * @dev Pay fees for a transaction or element id
+     *      This will only transfer funds if the fee  has not been paid
+     * @param _from Address from where the fees are being extracted
+     * @param _id Escrow id or element identifier to mark as paid
+     * @param _value Value sold in the escrow
+     * @param _tokenAddress Address of the token sold in the escrow
+     */
+    function _payFee(address _from, uint _id, uint _value, address _tokenAddress) internal {
+        if (feePaid[_id]) return;
+
+        feePaid[_id] = true;
+        uint feeAmount = _getValueOffMillipercent(_value, feeMilliPercent);
+        feeTokenBalances[_tokenAddress] += feeAmount;
+
+        if (_tokenAddress != address(0)) {
+            require(msg.value == 0, "Cannot send ETH with token address different from 0");
+
+            ERC20Token tokenToPay = ERC20Token(_tokenAddress);
+            require(_safeTransferFrom(tokenToPay, _from, address(this), feeAmount + _value), "Unsuccessful token transfer");
+        } else {
+            require(msg.value == (_value + feeAmount), "ETH amount is required");
+        }
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/IEscrow.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/IEscrow.sol
@@ -1,0 +1,53 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+contract IEscrow {
+
+  enum EscrowStatus {CREATED, FUNDED, PAID, RELEASED, CANCELED}
+
+  struct EscrowTransaction {
+      uint256 offerId;
+      address token;
+      uint256 tokenAmount;
+      uint256 expirationTime;
+      uint256 sellerRating;
+      uint256 buyerRating;
+      uint256 fiatAmount;
+      address payable buyer;
+      address payable seller;
+      address payable arbitrator;
+      address payable destination;
+      EscrowStatus status;
+  }
+
+  function createEscrow_relayed(
+        address payable _sender,
+        uint _offerId,
+        uint _tokenAmount,
+        uint _fiatAmount,
+        address payable _destination,
+        string calldata _contactData,
+        string calldata _location,
+        string calldata _username
+    ) external returns(uint escrowId);
+
+  function updateDestination(uint _escrowId, address payable _destination) external;
+
+  function pay(uint _escrowId) external;
+
+  function pay_relayed(address _sender, uint _escrowId) external;
+
+  function cancel(uint _escrowId) external;
+
+  function cancel_relayed(address _sender, uint _escrowId) external;
+
+  function openCase(uint  _escrowId, uint8 _motive) external;
+
+  function openCase_relayed(address _sender, uint256 _escrowId, uint8 _motive) external;
+
+  function rateTransaction(uint _escrowId, uint _rate) external;
+
+  function rateTransaction_relayed(address _sender, uint _escrowId, uint _rate) external;
+
+  function getBasicTradeData(uint _escrowId) external view returns(address payable buyer, address payable seller, address token, uint tokenAmount);
+
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/License.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/License.sol
@@ -1,0 +1,166 @@
+/* solium-disable security/no-block-members */
+/* solium-disable security/no-inline-assembly */
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../common/Ownable.sol";
+import "../token/ERC20Token.sol";
+import "../token/SafeTransfer.sol";
+import "../token/ApproveAndCallFallBack.sol";
+import "../proxy/Proxiable.sol";
+
+/**
+* @title License
+* @dev Contract for buying a license
+*/
+contract License is Ownable, ApproveAndCallFallBack, SafeTransfer, Proxiable {
+    uint256 public price;
+
+    ERC20Token token;
+    address burnAddress;
+
+    struct LicenseDetails {
+        uint price;
+        uint creationTime;
+    }
+
+    address[] public licenseOwners;
+    mapping(address => uint) public idxLicenseOwners;
+    mapping(address => LicenseDetails) public licenseDetails;
+
+    event Bought(address buyer, uint256 price);
+    event PriceChanged(uint256 _price);
+    event BurnAddressChanged(address sender, address prevBurnAddress, address newBurnAddress);
+
+    /**
+     * @dev Changes the burn address
+     * @param _burnAddress New burn address
+     */
+    function setBurnAddress(address payable _burnAddress) external onlyOwner {
+        emit BurnAddressChanged(msg.sender, burnAddress, _burnAddress);
+        burnAddress = _burnAddress;
+    }
+
+    /**
+     * @param _tokenAddress Address of token used to pay for licenses (SNT)
+     * @param _price Price of the licenses
+     * @param _burnAddress Address where the license fee is going to be sent
+     */
+    constructor(address _tokenAddress, uint256 _price, address _burnAddress) public {
+        init(_tokenAddress, _price, _burnAddress);
+    }
+
+    /**
+     * @dev Initialize contract (used with proxy). Can only be called once
+     * @param _tokenAddress Address of token used to pay for licenses (SNT)
+     * @param _price Price of the licenses
+     * @param _burnAddress Address where the license fee is going to be sent
+     */
+    function init(
+        address _tokenAddress,
+        uint256 _price,
+        address _burnAddress
+    ) public {
+        assert(_initialized == false);
+
+        _initialized = true;
+
+        price = _price;
+        token = ERC20Token(_tokenAddress);
+        burnAddress = _burnAddress;
+
+        _setOwner(msg.sender);
+    }
+
+    function updateCode(address newCode) public onlyOwner {
+        updateCodeAddress(newCode);
+    }
+
+    /**
+     * @notice Check if the address already owns a license
+     * @param _address The address to check
+     * @return bool
+     */
+    function isLicenseOwner(address _address) public view returns (bool) {
+        return licenseDetails[_address].price != 0 && licenseDetails[_address].creationTime != 0;
+    }
+
+    /**
+     * @notice Buy a license
+     * @dev Requires value to be equal to the price of the license.
+     *      The msg.sender must not already own a license.
+     */
+    function buy() external returns(uint) {
+        uint id = _buyFrom(msg.sender);
+        return id;
+    }
+
+    /**
+     * @notice Buy a license
+     * @dev Requires value to be equal to the price of the license.
+     *      The _owner must not already own a license.
+     */
+    function _buyFrom(address _licenseOwner) internal returns(uint) {
+        require(licenseDetails[_licenseOwner].creationTime == 0, "License already bought");
+
+        licenseDetails[_licenseOwner] = LicenseDetails({
+            price: price,
+            creationTime: block.timestamp
+        });
+
+        uint idx = licenseOwners.push(_licenseOwner);
+        idxLicenseOwners[_licenseOwner] = idx;
+
+        emit Bought(_licenseOwner, price);
+
+        require(_safeTransferFrom(token, _licenseOwner, burnAddress, price), "Unsuccessful token transfer");
+
+        return idx;
+    }
+
+    /**
+     * @notice Set the license price
+     * @param _price The new price of the license
+     * @dev Only the owner of the contract can perform this action
+    */
+    function setPrice(uint256 _price) external onlyOwner {
+        price = _price;
+        emit PriceChanged(_price);
+    }
+
+    /**
+     * @dev Get number of license owners
+     * @return uint
+     */
+    function getNumLicenseOwners() external view returns (uint256) {
+        return licenseOwners.length;
+    }
+
+    /**
+     * @notice Support for "approveAndCall". Callable only by `token()`.
+     * @param _from Who approved.
+     * @param _amount Amount being approved, need to be equal `price()`.
+     * @param _token Token being approved, need to be equal `token()`.
+     * @param _data Abi encoded data with selector of `buy(and)`.
+     */
+    function receiveApproval(address _from, uint256 _amount, address _token, bytes memory _data) public {
+        require(_amount == price, "Wrong value");
+        require(_token == address(token), "Wrong token");
+        require(_token == address(msg.sender), "Wrong call");
+        require(_data.length == 4, "Wrong data length");
+
+        require(_abiDecodeBuy(_data) == bytes4(0xa6f2ae3a), "Wrong method selector"); //bytes4(keccak256("buy()"))
+
+        _buyFrom(_from);
+    }
+
+    /**
+     * @dev Decodes abi encoded data with selector for "buy()".
+     * @param _data Abi encoded data.
+     * @return Decoded registry call.
+     */
+    function _abiDecodeBuy(bytes memory _data) internal pure returns(bytes4 sig) {
+        assembly {
+            sig := mload(add(_data, add(0x20, 0)))
+        }
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/OfferStore.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/OfferStore.sol
@@ -1,0 +1,326 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./UserStore.sol";
+import "./License.sol";
+import "./ArbitrationLicense.sol";
+import "../common/SecuredFunctions.sol";
+import "../common/USDStakable.sol";
+import "../common/Medianizer.sol";
+import "../proxy/Proxiable.sol";
+
+
+/**
+* @title OfferStore
+* @dev Offers registry
+*/
+contract OfferStore is USDStakable, SecuredFunctions, Proxiable {
+
+    struct Offer {
+        int16 margin;
+        uint[] paymentMethods;
+        uint limitL;
+        uint limitU;
+        address asset;
+        string currency;
+        address payable owner;
+        address payable arbitrator;
+        bool deleted;
+    }
+
+    License public sellingLicenses;
+    ArbitrationLicense public arbitrationLicenses;
+    UserStore public userStore;
+
+    Offer[] public offers;
+    mapping(address => uint256[]) public addressToOffers;
+    mapping(address => mapping (uint256 => bool)) public offerWhitelist;
+
+    uint public maxOffers = 10;
+    mapping(address => uint) public offerCnt;
+
+    event OfferAdded(
+        address owner,
+        uint256 offerId,
+        address asset,
+        string location,
+        string currency,
+        string username,
+        uint[] paymentMethods,
+        uint limitL,
+        uint limitU,
+        int16 margin
+    );
+
+    event OfferRemoved(address owner, uint256 offerId);
+
+    /**
+     * @param _userStore User store contract address
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     * @param _burnAddress Address to send slashed offer funds
+     * @param _medianizer DAI medianizer to obtain USD price
+     */
+    constructor(address _userStore, address _sellingLicenses, address _arbitrationLicenses, address payable _burnAddress, address _medianizer) public
+        USDStakable(_burnAddress, _medianizer)
+    {
+        init(_userStore, _sellingLicenses, _arbitrationLicenses, _burnAddress, _medianizer);
+    }
+
+    /**
+     * @dev Initialize contract (used with proxy). Can only be called once
+     * @param _userStore User store contract address
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     * @param _burnAddress Address to send slashed offer funds
+     */
+    function init(
+        address _userStore,
+        address _sellingLicenses,
+        address _arbitrationLicenses,
+        address payable _burnAddress,
+        address _medianizer
+    ) public {
+        assert(_initialized == false);
+
+        _initialized = true;
+
+        userStore = UserStore(_userStore);
+        sellingLicenses = License(_sellingLicenses);
+        arbitrationLicenses = ArbitrationLicense(_arbitrationLicenses);
+        burnAddress = _burnAddress;
+
+        maxOffers = 10;
+        basePrice = 1 ether; // 1 USD
+        medianizer = Medianizer(_medianizer);
+
+        _setOwner(msg.sender);
+    }
+
+    function updateCode(address newCode) public onlyOwner {
+        updateCodeAddress(newCode);
+    }
+
+    event LicensesChanged(address sender, address oldSellingLicenses, address newSellingLicenses, address oldArbitrationLicenses, address newArbitrationLicenses);
+
+    /**
+     * @dev Change license addresses
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     */
+    function setLicenses(
+        address _sellingLicenses,
+        address _arbitrationLicenses
+    ) public onlyOwner {
+        emit LicensesChanged(msg.sender, address(sellingLicenses), address(_sellingLicenses), address(arbitrationLicenses), (_arbitrationLicenses));
+
+        sellingLicenses = License(_sellingLicenses);
+        arbitrationLicenses = ArbitrationLicense(_arbitrationLicenses);
+    }
+
+    event MaxOffersChanged(address sender, uint oldMax, uint newMax);
+
+    /**
+     * @dev Change max offers allowed per seller
+     * @param _newMax New max offers amount
+     */
+    function setMaxOffers(
+        uint _newMax
+    ) public onlyOwner {
+        emit MaxOffersChanged(msg.sender, maxOffers, _newMax);
+        maxOffers = _newMax;
+    }
+
+    /**
+    * @dev Add a new offer with a new user if needed to the list
+    * @param _asset The address of the erc20 to exchange, pass 0x0 for Eth
+    * @param _contactData Contact Data   ContactType:UserId
+    * @param _location The location on earth
+    * @param _currency The currency the user want to receive (USD, EUR...)
+    * @param _username The username of the user
+    * @param _paymentMethods The list of the payment methods the user accept
+    * @param _limitL Lower limit accepted
+    * @param _limitU Upper limit accepted
+    * @param _margin The margin for the user
+    * @param _arbitrator The arbitrator used by the offer
+    */
+    function addOffer(
+        address _asset,
+        string memory _contactData,
+        string memory _location,
+        string memory _currency,
+        string memory _username,
+        uint[] memory _paymentMethods,
+        uint _limitL,
+        uint _limitU,
+        int16 _margin,
+        address payable _arbitrator
+    ) public payable {
+        //require(sellingLicenses.isLicenseOwner(msg.sender), "Not a license owner");
+
+        require(offerCnt[msg.sender] < maxOffers, "Exceeds the max number of offers");
+        require(arbitrationLicenses.isAllowed(msg.sender, _arbitrator), "Arbitrator does not allow this transaction");
+
+        require(_limitL <= _limitU, "Invalid limits");
+        require(msg.sender != _arbitrator, "Cannot arbitrate own offers");
+
+        userStore.addOrUpdateUser(
+            msg.sender,
+            _contactData,
+            _location,
+            _username
+        );
+
+        Offer memory newOffer = Offer(
+            _margin,
+            _paymentMethods,
+            _limitL,
+            _limitU,
+            _asset,
+            _currency,
+            msg.sender,
+            _arbitrator,
+            false
+        );
+
+        uint256 offerId = offers.push(newOffer) - 1;
+        offerWhitelist[msg.sender][offerId] = true;
+        addressToOffers[msg.sender].push(offerId);
+        offerCnt[msg.sender]++;
+
+        emit OfferAdded(
+            msg.sender,
+            offerId,
+            _asset,
+            _location,
+            _currency,
+            _username,
+            _paymentMethods,
+            _limitL,
+            _limitU,
+            _margin);
+
+        _stake(offerId, msg.sender, _asset);
+    }
+
+    /**
+     * @notice Remove user offer
+     * @dev Removed offers are marked as deleted instead of being deleted
+     * @param _offerId Id of the offer to remove
+     */
+    function removeOffer(uint256 _offerId) external {
+        require(offerWhitelist[msg.sender][_offerId], "Offer does not exist");
+
+        offers[_offerId].deleted = true;
+        offerWhitelist[msg.sender][_offerId] = false;
+        emit OfferRemoved(msg.sender, _offerId);
+
+        if(offerCnt[msg.sender] - 1 > offerCnt[msg.sender]){
+            offerCnt[msg.sender] = 0;
+        } else {
+            offerCnt[msg.sender]--;
+        }
+
+        _unstake(_offerId);
+    }
+
+    /**
+     * @notice Get the offer by Id
+     * @dev normally we'd access the offers array, but it would not return the payment methods
+     * @param _id Offer id
+     * @return Offer data (see Offer struct)
+     */
+    function offer(uint256 _id) external view returns (
+        address asset,
+        string memory currency,
+        int16 margin,
+        uint[] memory paymentMethods,
+        uint limitL,
+        uint limitU,
+        address payable owner,
+        address payable arbitrator,
+        bool deleted
+    ) {
+        Offer memory theOffer = offers[_id];
+
+        // In case arbitrator rejects the seller
+        address payable offerArbitrator = theOffer.arbitrator;
+        if(!arbitrationLicenses.isAllowed(theOffer.owner, offerArbitrator)){
+            offerArbitrator = address(0);
+        }
+
+        return (
+            theOffer.asset,
+            theOffer.currency,
+            theOffer.margin,
+            theOffer.paymentMethods,
+            theOffer.limitL,
+            theOffer.limitU,
+            theOffer.owner,
+            offerArbitrator,
+            theOffer.deleted
+        );
+    }
+
+    /**
+     * @notice Get the offer's owner by Id
+     * @dev Helper function
+     * @param _id Offer id
+     * @return Seller address
+     */
+    function getOfferOwner(uint256 _id) external view returns (address payable) {
+        return (offers[_id].owner);
+    }
+
+    /**
+     * @notice Get the offer's asset by Id
+     * @dev Helper function
+     * @param _id Offer id
+     * @return Token address used in the offer
+     */
+    function getAsset(uint256 _id) external view returns (address) {
+        return (offers[_id].asset);
+    }
+
+    /**
+     * @notice Get the offer's arbitrator by Id
+     * @dev Helper function
+     * @param _id Offer id
+     * @return Arbitrator address
+     */
+    function getArbitrator(uint256 _id) external view returns (address payable) {
+        return (offers[_id].arbitrator);
+    }
+
+    /**
+     * @notice Get the size of the offers
+     * @return Number of offers stored in the contract
+     */
+    function offersSize() external view returns (uint256) {
+        return offers.length;
+    }
+
+    /**
+     * @notice Get all the offer ids of the address in params
+     * @param _address Address of the offers
+     * @return Array of offer ids for a specific address
+     */
+    function getOfferIds(address _address) external view returns (uint256[] memory) {
+        return addressToOffers[_address];
+    }
+
+    /**
+     * @dev Slash offer stake. If the sender is not the escrow contract, nothing will happen
+     * @param _offerId Offer Id to slash
+     */
+    function slashStake(uint _offerId) external onlyAllowedContracts {
+        _slash(_offerId);
+    }
+
+    /**
+     * @dev Refunds a stake. Can be called automatically after an escrow is released
+     * @param _offerId Offer Id to slash
+     */
+    function refundStake(uint _offerId) external onlyAllowedContracts {
+        _refundStake(_offerId);
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/teller-network/UserStore.sol
+++ b/dapps/tests/teller-contracts/contracts/teller-network/UserStore.sol
@@ -1,0 +1,213 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./License.sol";
+import "./ArbitrationLicense.sol";
+import "../common/MessageSigned.sol";
+import "../common/SecuredFunctions.sol";
+import "../proxy/Proxiable.sol";
+
+
+/**
+* @title UserStore
+* @dev Users registry
+*/
+contract UserStore is MessageSigned, SecuredFunctions, Proxiable {
+
+    struct User {
+        string contactData;
+        string location;
+        string username;
+    }
+
+    License public sellingLicenses;
+    ArbitrationLicense public arbitrationLicenses;
+
+    mapping(address => User) public users;
+    mapping(address => uint) public user_nonce;
+
+    /**
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     */
+    constructor(address _sellingLicenses, address _arbitrationLicenses) public
+    {
+        init(_sellingLicenses, _arbitrationLicenses);
+    }
+
+    /**
+     * @dev Initialize contract (used with proxy). Can only be called once
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     */
+    function init(
+        address _sellingLicenses,
+        address _arbitrationLicenses
+    ) public {
+        assert(_initialized == false);
+
+        _initialized = true;
+
+        sellingLicenses = License(_sellingLicenses);
+        arbitrationLicenses = ArbitrationLicense(_arbitrationLicenses);
+
+        _setOwner(msg.sender);
+    }
+
+    function updateCode(address newCode) public onlyOwner {
+        updateCodeAddress(newCode);
+    }
+
+    event LicensesChanged(address sender, address oldSellingLicenses, address newSellingLicenses, address oldArbitrationLicenses, address newArbitrationLicenses);
+
+    /**
+     * @dev Initialize contract (used with proxy). Can only be called once
+     * @param _sellingLicenses Sellers licenses contract address
+     * @param _arbitrationLicenses Arbitrators licenses contract address
+     */
+    function setLicenses(
+        address _sellingLicenses,
+        address _arbitrationLicenses
+    ) public onlyOwner {
+        emit LicensesChanged(msg.sender, address(sellingLicenses), address(_sellingLicenses), address(arbitrationLicenses), (_arbitrationLicenses));
+
+        sellingLicenses = License(_sellingLicenses);
+        arbitrationLicenses = ArbitrationLicense(_arbitrationLicenses);
+    }
+
+    /**
+     * @dev Get datahash to be signed
+     * @param _username Username
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _nonce Nonce value (obtained from user_nonce)
+     * @return bytes32 to sign
+     */
+    function _dataHash(string memory _username, string memory _contactData, uint _nonce) internal view returns (bytes32) {
+        uint256 cid;
+        assembly { 
+		    cid := chainid()
+		}
+        return keccak256(abi.encodePacked(address(this), _username, _contactData, _nonce, cid));
+    }
+
+    /**
+     * @notice Get datahash to be signed
+     * @param _username Username
+     * @param _contactData Contact Data   ContactType:UserId
+     * @return bytes32 to sign
+     */
+    function getDataHash(string calldata _username, string calldata _contactData) external view returns (bytes32) {
+        return _dataHash(_username, _contactData, user_nonce[msg.sender]);
+    }
+
+    /**
+     * @dev Get signer address from signature. This uses the signature parameters to validate the signature
+     * @param _username Status username
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _nonce User nonce
+     * @param _signature Signature obtained from the previous parameters
+     * @return Signing user address
+     */
+    function _getSigner(
+        string memory _username,
+        string memory _contactData,
+        uint _nonce,
+        bytes memory _signature
+    ) internal view returns(address) {
+        bytes32 signHash = _getSignHash(_dataHash(_username, _contactData, _nonce));
+        return _recoverAddress(signHash, _signature);
+    }
+
+    /**
+     * @notice Get signer address from signature
+     * @param _username Status username
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _nonce User nonce
+     * @param _signature Signature obtained from the previous parameters
+     * @return Signing user address
+     */
+    function getMessageSigner(
+        string calldata _username,
+        string calldata _contactData,
+        uint _nonce,
+        bytes calldata _signature
+    ) external view returns(address) {
+        return _getSigner(_username, _contactData, _nonce, _signature);
+    }
+
+    /**
+     * @dev Adds or updates user information
+     * @param _user User address to update
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _location New location
+     * @param _username New status username
+     */
+    function _addOrUpdateUser(
+        address _user,
+        string memory _contactData,
+        string memory _location,
+        string memory _username
+    ) internal {
+        User storage u = users[_user];
+        u.contactData = _contactData;
+        u.location = _location;
+        u.username = _username;
+    }
+
+    /**
+     * @notice Adds or updates user information via signature
+     * @param _signature Signature
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _location New location
+     * @param _username New status username
+     * @return Signing user address
+     */
+    function addOrUpdateUser(
+        bytes calldata _signature,
+        string calldata _contactData,
+        string calldata _location,
+        string calldata _username,
+        uint _nonce
+    ) external returns(address payable _user) {
+        _user = address(uint160(_getSigner(_username, _contactData, _nonce, _signature)));
+
+        require(_nonce == user_nonce[_user], "Invalid nonce");
+
+        user_nonce[_user]++;
+        _addOrUpdateUser(_user, _contactData, _location, _username);
+
+        return _user;
+    }
+
+    /**
+     * @notice Adds or updates user information
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _location New location
+     * @param _username New status username
+     * @return Signing user address
+     */
+    function addOrUpdateUser(
+        string calldata _contactData,
+        string calldata _location,
+        string calldata _username
+    ) external {
+        _addOrUpdateUser(msg.sender, _contactData, _location, _username);
+    }
+
+    /**
+     * @notice Adds or updates user information
+     * @dev can only be called by the escrow contract
+     * @param _sender Address that sets the user info
+     * @param _contactData Contact Data   ContactType:UserId
+     * @param _location New location
+     * @param _username New status username
+     * @return Signing user address
+     */
+    function addOrUpdateUser(
+        address _sender,
+        string calldata _contactData,
+        string calldata _location,
+        string calldata _username
+    ) external onlyAllowedContracts {
+        _addOrUpdateUser(_sender, _contactData, _location, _username);
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/test/StandardToken.sol
+++ b/dapps/tests/teller-contracts/contracts/test/StandardToken.sol
@@ -1,0 +1,149 @@
+pragma solidity ^0.5.7;
+
+import "../token/ERC20Token.sol";
+
+
+/**
+ * @notice Standard ERC20 token for tests
+ */
+contract StandardToken is ERC20Token {
+
+    uint256 private supply;
+    mapping (address => uint256) balances;
+    mapping (address => mapping (address => uint256)) allowed;
+
+    constructor() public { }
+
+    /**
+     * @notice send `_value` token to `_to` from `msg.sender`
+     * @param _to The address of the recipient
+     * @param _value The amount of token to be transferred
+     * @return Whether the transfer was successful or not
+     */
+    function transfer(
+        address _to,
+        uint256 _value
+    )
+        external
+        returns (bool success)
+    {
+        return transfer(msg.sender, _to, _value);
+    }
+
+    /**
+     * @notice `msg.sender` approves `_spender` to spend `_value` tokens
+     * @param _spender The address of the account able to transfer the tokens
+     * @param _value The amount of tokens to be approved for transfer
+     * @return Whether the approval was successful or not
+     */
+    function approve(address _spender, uint256 _value)
+        external
+        returns (bool success)
+    {
+        allowed[msg.sender][_spender] = _value;
+        emit Approval(msg.sender, _spender, _value);
+        return true;
+    }
+
+    /**
+     * @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
+     * @param _from The address of the sender
+     * @param _to The address of the recipient
+     * @param _value The amount of token to be transferred
+     * @return Whether the transfer was successful or not
+     */
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    )
+        external
+        returns (bool success)
+    {
+        if (balances[_from] >= _value &&
+            allowed[_from][msg.sender] >= _value &&
+            _value > 0) {
+            allowed[_from][msg.sender] -= _value;
+            return transfer(_from, _to, _value);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @param _owner The address from which the balance will be retrieved
+     * @param _spender The address of the account able to spend the tokens
+     * @return The balance
+     */
+    function allowance(address _owner, address _spender)
+        external
+        view
+        returns (uint256 remaining)
+    {
+        return allowed[_owner][_spender];
+    }
+
+    /**
+     * @param _owner The address of the account owning tokens
+     * @return Amount of remaining tokens allowed to spent
+     */
+    function balanceOf(address _owner)
+        external
+        view
+        returns (uint256 balance)
+    {
+        return balances[_owner];
+    }
+
+    /**
+     * @notice return total supply of tokens
+     */
+    function totalSupply()
+        external
+        view
+        returns(uint256 currentTotalSupply)
+    {
+        return supply;
+    }
+
+    /**
+     * @notice Mints tokens for testing
+     */
+    function mint(
+        address _to,
+        uint256 _amount
+    )
+        public
+    {
+        balances[_to] += _amount;
+        supply += _amount;
+        emit Transfer(address(0), _to, _amount);
+    }
+
+     /**
+     * @notice send `_value` token to `_to` from `_from`
+     * @param _from The address of the sender
+     * @param _to The address of the recipient
+     * @param _value The amount of token to be transferred
+     * @return Whether the transfer was successful or not
+     */
+    function transfer(
+        address _from,
+        address _to,
+        uint256 _value
+    )
+        internal
+        returns (bool success)
+    {
+        if (balances[_from] >= _value && _value > 0) {
+            balances[_from] -= _value;
+            balances[_to] += _value;
+            emit Transfer(_from, _to, _value);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+}

--- a/dapps/tests/teller-contracts/contracts/test/TestEscrowUpgrade.sol
+++ b/dapps/tests/teller-contracts/contracts/test/TestEscrowUpgrade.sol
@@ -1,0 +1,36 @@
+/* solium-disable security/no-block-members */
+/* solium-disable no-empty-blocks */
+
+pragma solidity >=0.5.0 <0.6.0;
+
+import "../teller-network/Escrow.sol";
+
+/**
+ * @title Test Escrow Upgrade contract
+ */
+contract TestEscrowUpgrade is Escrow {
+
+    constructor (
+        address _fallbackArbitrator,
+        address _relayer,
+        address _arbitrationLicense,
+        address _offerStore,
+        address _userStore,
+        address payable _feeDestination,
+        uint _feeMilliPercent
+      )
+      Escrow(_fallbackArbitrator, _relayer, _arbitrationLicense, _offerStore, _userStore, _feeDestination, _feeMilliPercent)
+      public {
+    }
+
+    uint private val;
+
+    function getVal() public view returns (uint) {
+        return val;
+    }
+
+    function setVal(uint _val) public {
+      val = _val;
+    }
+
+}

--- a/dapps/tests/teller-contracts/contracts/token/ApproveAndCallFallBack.sol
+++ b/dapps/tests/teller-contracts/contracts/token/ApproveAndCallFallBack.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.5.7;
+
+contract ApproveAndCallFallBack {
+    function receiveApproval(address from, uint256 _amount, address _token, bytes memory _data) public;
+}

--- a/dapps/tests/teller-contracts/contracts/token/ERC20Token.sol
+++ b/dapps/tests/teller-contracts/contracts/token/ERC20Token.sol
@@ -1,0 +1,53 @@
+pragma solidity ^0.5.7;
+
+// Abstract contract for the full ERC 20 Token standard
+// https://github.com/ethereum/EIPs/issues/20
+
+interface ERC20Token {
+
+    /**
+     * @notice send `_value` token to `_to` from `msg.sender`
+     * @param _to The address of the recipient
+     * @param _value The amount of token to be transferred
+     * @return Whether the transfer was successful or not
+     */
+    function transfer(address _to, uint256 _value) external returns (bool success);
+
+    /**
+     * @notice `msg.sender` approves `_spender` to spend `_value` tokens
+     * @param _spender The address of the account able to transfer the tokens
+     * @param _value The amount of tokens to be approved for transfer
+     * @return Whether the approval was successful or not
+     */
+    function approve(address _spender, uint256 _value) external returns (bool success);
+
+    /**
+     * @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
+     * @param _from The address of the sender
+     * @param _to The address of the recipient
+     * @param _value The amount of token to be transferred
+     * @return Whether the transfer was successful or not
+     */
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+
+    /**
+     * @param _owner The address from which the balance will be retrieved
+     * @return The balance
+     */
+    function balanceOf(address _owner) external view returns (uint256 balance);
+
+    /**
+     * @param _owner The address of the account owning tokens
+     * @param _spender The address of the account able to transfer the tokens
+     * @return Amount of remaining tokens allowed to spent
+     */
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining);
+
+    /**
+     * @notice return total supply of tokens
+     */
+    function totalSupply() external view returns (uint256 supply);
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+}

--- a/dapps/tests/teller-contracts/contracts/token/MiniMeToken.sol
+++ b/dapps/tests/teller-contracts/contracts/token/MiniMeToken.sol
@@ -1,0 +1,637 @@
+pragma solidity ^0.5.7;
+
+/*
+    Copyright 2016, Jordi Baylina
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @title MiniMeToken Contract
+ * @author Jordi Baylina
+ * @dev This token contract's goal is to make it easy for anyone to clone this
+ *  token using the token distribution at a given block, this will allow DAO's
+ *  and DApps to upgrade their features in a decentralized manner without
+ *  affecting the original token
+ * @dev It is ERC20 compliant, but still needs to under go further testing.
+ */
+
+import "../common/Controlled.sol";
+import "./TokenController.sol";
+import "./ApproveAndCallFallBack.sol";
+import "./MiniMeTokenInterface.sol";
+import "./TokenFactory.sol";
+
+/**
+ * @dev The actual token contract, the default controller is the msg.sender
+ *  that deploys the contract, so usually this token will be deployed by a
+ *  token controller contract, which Giveth will call a "Campaign"
+ */
+contract MiniMeToken is MiniMeTokenInterface, Controlled {
+
+    string public name;                //The Token's name: e.g. DigixDAO Tokens
+    uint8 public decimals;             //Number of decimals of the smallest unit
+    string public symbol;              //An identifier: e.g. REP
+    string public version = "MMT_0.1"; //An arbitrary versioning scheme
+
+    /**
+     * @dev `Checkpoint` is the structure that attaches a block number to a
+     *  given value, the block number attached is the one that last changed the
+     *  value
+     */
+    struct Checkpoint {
+
+        // `fromBlock` is the block number that the value was generated from
+        uint128 fromBlock;
+
+        // `value` is the amount of tokens at a specific block number
+        uint128 value;
+    }
+
+    // `parentToken` is the Token address that was cloned to produce this token;
+    //  it will be 0x0 for a token that was not cloned
+    MiniMeToken public parentToken;
+
+    // `parentSnapShotBlock` is the block number from the Parent Token that was
+    //  used to determine the initial distribution of the Clone Token
+    uint public parentSnapShotBlock;
+
+    // `creationBlock` is the block number that the Clone Token was created
+    uint public creationBlock;
+
+    // `balances` is the map that tracks the balance of each address, in this
+    //  contract when the balance changes the block number that the change
+    //  occurred is also included in the map
+    mapping (address => Checkpoint[]) balances;
+
+    // `allowed` tracks any extra transfer rights as in all ERC20 tokens
+    mapping (address => mapping (address => uint256)) allowed;
+
+    // Tracks the history of the `totalSupply` of the token
+    Checkpoint[] totalSupplyHistory;
+
+    // Flag that determines if the token is transferable or not.
+    bool public transfersEnabled;
+
+    // The factory used to create new clone tokens
+    TokenFactory public tokenFactory;
+
+////////////////
+// Constructor
+////////////////
+
+    /**
+     * @notice Constructor to create a MiniMeToken
+     * @param _tokenFactory The address of the MiniMeTokenFactory contract that
+     *  will create the Clone token contracts, the token factory needs to be
+     *  deployed first
+     * @param _parentToken Address of the parent token, set to 0x0 if it is a
+     *  new token
+     * @param _parentSnapShotBlock Block of the parent token that will
+     *  determine the initial distribution of the clone token, set to 0 if it
+     *  is a new token
+     * @param _tokenName Name of the new token
+     * @param _decimalUnits Number of decimals of the new token
+     * @param _tokenSymbol Token Symbol for the new token
+     * @param _transfersEnabled If true, tokens will be able to be transferred
+     */
+    constructor(
+        address _tokenFactory,
+        address _parentToken,
+        uint _parentSnapShotBlock,
+        string memory _tokenName,
+        uint8 _decimalUnits,
+        string memory _tokenSymbol,
+        bool _transfersEnabled
+    )
+        public
+    {
+        tokenFactory = TokenFactory(_tokenFactory);
+        name = _tokenName;                                 // Set the name
+        decimals = _decimalUnits;                          // Set the decimals
+        symbol = _tokenSymbol;                             // Set the symbol
+        parentToken = MiniMeToken(address(uint160(_parentToken)));
+        parentSnapShotBlock = _parentSnapShotBlock;
+        transfersEnabled = _transfersEnabled;
+        creationBlock = block.number;
+    }
+
+
+///////////////////
+// ERC20 Methods
+///////////////////
+
+    /**
+     * @notice Send `_amount` tokens to `_to` from `msg.sender`
+     * @param _to The address of the recipient
+     * @param _amount The amount of tokens to be transferred
+     * @return Whether the transfer was successful or not
+     */
+    function transfer(address _to, uint256 _amount) public returns (bool success) {
+        require(transfersEnabled);
+        return doTransfer(msg.sender, _to, _amount);
+    }
+
+    /**
+     * @notice Send `_amount` tokens to `_to` from `_from` on the condition it
+     *  is approved by `_from`
+     * @param _from The address holding the tokens being transferred
+     * @param _to The address of the recipient
+     * @param _amount The amount of tokens to be transferred
+     * @return True if the transfer was successful
+     */
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _amount
+    )
+        public
+        returns (bool success)
+    {
+
+        // The controller of this contract can move tokens around at will,
+        //  this is important to recognize! Confirm that you trust the
+        //  controller of this contract, which in most situations should be
+        //  another open source smart contract or 0x0
+        if (msg.sender != controller) {
+            require(transfersEnabled);
+
+            // The standard ERC 20 transferFrom functionality
+            if (allowed[_from][msg.sender] < _amount) {
+                return false;
+            }
+            allowed[_from][msg.sender] -= _amount;
+        }
+        return doTransfer(_from, _to, _amount);
+    }
+
+    /**
+     * @dev This is the actual transfer function in the token contract, it can
+     *  only be called by other functions in this contract.
+     * @param _from The address holding the tokens being transferred
+     * @param _to The address of the recipient
+     * @param _amount The amount of tokens to be transferred
+     * @return True if the transfer was successful
+     */
+    function doTransfer(
+        address _from,
+        address _to,
+        uint _amount
+    )
+        internal
+        returns(bool)
+    {
+
+        if (_amount == 0) {
+            return true;
+        }
+
+        require(parentSnapShotBlock < block.number);
+
+        // Do not allow transfer to 0x0 or the token contract itself
+        require((_to != address(0)) && (_to != address(this)));
+
+        // If the amount being transfered is more than the balance of the
+        //  account the transfer returns false
+        uint256 previousBalanceFrom = balanceOfAt(_from, block.number);
+        if (previousBalanceFrom < _amount) {
+            return false;
+        }
+
+        // Alerts the token controller of the transfer
+        if (isContract(controller)) {
+            require(TokenController(controller).onTransfer(_from, _to, _amount));
+        }
+
+        // First update the balance array with the new value for the address
+        //  sending the tokens
+        updateValueAtNow(balances[_from], previousBalanceFrom - _amount);
+
+        // Then update the balance array with the new value for the address
+        //  receiving the tokens
+        uint256 previousBalanceTo = balanceOfAt(_to, block.number);
+        require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
+        updateValueAtNow(balances[_to], previousBalanceTo + _amount);
+
+        // An event to make the transfer easy to find on the blockchain
+        emit Transfer(_from, _to, _amount);
+
+        return true;
+    }
+
+    function doApprove(
+        address _from,
+        address _spender,
+        uint256 _amount
+    )
+        internal
+        returns (bool)
+    {
+        require(transfersEnabled);
+
+        // To change the approve amount you first have to reduce the addresses`
+        //  allowance to zero by calling `approve(_spender,0)` if it is not
+        //  already 0 to mitigate the race condition described here:
+        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        require((_amount == 0) || (allowed[_from][_spender] == 0));
+
+        // Alerts the token controller of the approve function call
+        if (isContract(controller)) {
+            require(TokenController(controller).onApprove(_from, _spender, _amount));
+        }
+
+        allowed[_from][_spender] = _amount;
+        emit Approval(_from, _spender, _amount);
+        return true;
+    }
+
+    /**
+     * @param _owner The address that's balance is being requested
+     * @return The balance of `_owner` at the current block
+     */
+    function balanceOf(address _owner) external view returns (uint256 balance) {
+        return balanceOfAt(_owner, block.number);
+    }
+
+    /**
+     * @notice `msg.sender` approves `_spender` to spend `_amount` tokens on
+     *  its behalf. This is a modified version of the ERC20 approve function
+     *  to be a little bit safer
+     * @param _spender The address of the account able to transfer the tokens
+     * @param _amount The amount of tokens to be approved for transfer
+     * @return True if the approval was successful
+     */
+    function approve(address _spender, uint256 _amount) external returns (bool success) {
+        return doApprove(msg.sender, _spender, _amount);
+    }
+
+    /**
+     * @dev This function makes it easy to read the `allowed[]` map
+     * @param _owner The address of the account that owns the token
+     * @param _spender The address of the account able to transfer the tokens
+     * @return Amount of remaining tokens of _owner that _spender is allowed
+     *  to spend
+     */
+    function allowance(
+        address _owner,
+        address _spender
+    )
+        external
+        view
+        returns (uint256 remaining)
+    {
+        return allowed[_owner][_spender];
+    }
+    /**
+     * @notice `msg.sender` approves `_spender` to send `_amount` tokens on
+     *  its behalf, and then a function is triggered in the contract that is
+     *  being approved, `_spender`. This allows users to use their tokens to
+     *  interact with contracts in one function call instead of two
+     * @param _spender The address of the contract able to transfer the tokens
+     * @param _amount The amount of tokens to be approved for transfer
+     * @return True if the function call was successful
+     */
+    function approveAndCall(
+        address _spender,
+        uint256 _amount,
+        bytes memory _extraData
+    )
+        public
+        returns (bool success)
+    {
+        require(doApprove(msg.sender, _spender, _amount));
+
+        ApproveAndCallFallBack(_spender).receiveApproval(
+            msg.sender,
+            _amount,
+            address(this),
+            _extraData
+        );
+
+        return true;
+    }
+
+    /**
+     * @dev This function makes it easy to get the total number of tokens
+     * @return The total number of tokens
+     */
+    function totalSupply() external view returns (uint) {
+        return totalSupplyAt(block.number);
+    }
+
+
+////////////////
+// Query balance and totalSupply in History
+////////////////
+
+    /**
+     * @dev Queries the balance of `_owner` at a specific `_blockNumber`
+     * @param _owner The address from which the balance will be retrieved
+     * @param _blockNumber The block number when the balance is queried
+     * @return The balance at `_blockNumber`
+     */
+    function balanceOfAt(
+        address _owner,
+        uint _blockNumber
+    )
+        public
+        view
+        returns (uint)
+    {
+
+        // These next few lines are used when the balance of the token is
+        //  requested before a check point was ever created for this token, it
+        //  requires that the `parentToken.balanceOfAt` be queried at the
+        //  genesis block for that token as this contains initial balance of
+        //  this token
+        if ((balances[_owner].length == 0)
+            || (balances[_owner][0].fromBlock > _blockNumber)) {
+            if (address(parentToken) != address(0)) {
+                return parentToken.balanceOfAt(_owner, min(_blockNumber, parentSnapShotBlock));
+            } else {
+                // Has no parent
+                return 0;
+            }
+
+        // This will return the expected balance during normal situations
+        } else {
+            return getValueAt(balances[_owner], _blockNumber);
+        }
+    }
+
+    /**
+     * @notice Total amount of tokens at a specific `_blockNumber`.
+     * @param _blockNumber The block number when the totalSupply is queried
+     * @return The total amount of tokens at `_blockNumber`
+     */
+    function totalSupplyAt(uint _blockNumber) public view returns(uint) {
+
+        // These next few lines are used when the totalSupply of the token is
+        //  requested before a check point was ever created for this token, it
+        //  requires that the `parentToken.totalSupplyAt` be queried at the
+        //  genesis block for this token as that contains totalSupply of this
+        //  token at this block number.
+        if ((totalSupplyHistory.length == 0)
+            || (totalSupplyHistory[0].fromBlock > _blockNumber)) {
+            if (address(parentToken) != address(0)) {
+                return parentToken.totalSupplyAt(min(_blockNumber, parentSnapShotBlock));
+            } else {
+                return 0;
+            }
+
+        // This will return the expected totalSupply during normal situations
+        } else {
+            return getValueAt(totalSupplyHistory, _blockNumber);
+        }
+    }
+
+////////////////
+// Clone Token Method
+////////////////
+
+    /**
+     * @notice Creates a new clone token with the initial distribution being
+     *  this token at `snapshotBlock`
+     * @param _cloneTokenName Name of the clone token
+     * @param _cloneDecimalUnits Number of decimals of the smallest unit
+     * @param _cloneTokenSymbol Symbol of the clone token
+     * @param _snapshotBlock Block when the distribution of the parent token is
+     *  copied to set the initial distribution of the new clone token;
+     *  if the block is zero than the actual block, the current block is used
+     * @param _transfersEnabled True if transfers are allowed in the clone
+     * @return The address of the new MiniMeToken Contract
+     */
+    function createCloneToken(
+        string memory _cloneTokenName,
+        uint8 _cloneDecimalUnits,
+        string memory _cloneTokenSymbol,
+        uint _snapshotBlock,
+        bool _transfersEnabled
+        )
+            public
+            returns(address)
+        {
+        uint snapshotBlock = _snapshotBlock;
+        if (snapshotBlock == 0) {
+            snapshotBlock = block.number;
+        }
+        MiniMeToken cloneToken = MiniMeToken(tokenFactory.createCloneToken(
+            address(this),
+            snapshotBlock,
+            _cloneTokenName,
+            _cloneDecimalUnits,
+            _cloneTokenSymbol,
+            _transfersEnabled
+            ));
+
+        cloneToken.changeController(msg.sender);
+
+        // An event to make the token easy to find on the blockchain
+        emit NewCloneToken(address(cloneToken), snapshotBlock);
+        return address(cloneToken);
+    }
+
+////////////////
+// Generate and destroy tokens
+////////////////
+
+    /**
+     * @notice Generates `_amount` tokens that are assigned to `_owner`
+     * @param _owner The address that will be assigned the new tokens
+     * @param _amount The quantity of tokens generated
+     * @return True if the tokens are generated correctly
+     */
+    function generateTokens(
+        address _owner,
+        uint _amount
+    )
+        public
+        onlyController
+        returns (bool)
+    {
+        uint curTotalSupply = totalSupplyAt(block.number);
+        require(curTotalSupply + _amount >= curTotalSupply); // Check for overflow
+        uint previousBalanceTo = balanceOfAt(_owner, block.number);
+        require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
+        updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);
+        updateValueAtNow(balances[_owner], previousBalanceTo + _amount);
+        emit Transfer(address(0), _owner, _amount);
+        return true;
+    }
+
+    /**
+     * @notice Burns `_amount` tokens from `_owner`
+     * @param _owner The address that will lose the tokens
+     * @param _amount The quantity of tokens to burn
+     * @return True if the tokens are burned correctly
+     */
+    function destroyTokens(
+        address _owner,
+        uint _amount
+    )
+        public
+        onlyController
+        returns (bool)
+    {
+        uint curTotalSupply = totalSupplyAt(block.number);
+        require(curTotalSupply >= _amount);
+        uint previousBalanceFrom = balanceOfAt(_owner, block.number);
+        require(previousBalanceFrom >= _amount);
+        updateValueAtNow(totalSupplyHistory, curTotalSupply - _amount);
+        updateValueAtNow(balances[_owner], previousBalanceFrom - _amount);
+        emit Transfer(_owner, address(0), _amount);
+        return true;
+    }
+
+////////////////
+// Enable tokens transfers
+////////////////
+
+    /**
+     * @notice Enables token holders to transfer their tokens freely if true
+     * @param _transfersEnabled True if transfers are allowed in the clone
+     */
+    function enableTransfers(bool _transfersEnabled) public onlyController {
+        transfersEnabled = _transfersEnabled;
+    }
+
+////////////////
+// Internal helper functions to query and set a value in a snapshot array
+////////////////
+
+    /**
+     * @dev `getValueAt` retrieves the number of tokens at a given block number
+     * @param checkpoints The history of values being queried
+     * @param _block The block number to retrieve the value at
+     * @return The number of tokens being queried
+     */
+    function getValueAt(
+        Checkpoint[] storage checkpoints,
+        uint _block
+    )
+        internal
+        view
+        returns (uint)
+    {
+        if (checkpoints.length == 0) {
+            return 0;
+        }
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length-1].fromBlock) {
+            return checkpoints[checkpoints.length-1].value;
+        }
+        if (_block < checkpoints[0].fromBlock) {
+            return 0;
+        }
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length-1;
+        while (max > min) {
+            uint mid = (max + min + 1) / 2;
+            if (checkpoints[mid].fromBlock<=_block) {
+                min = mid;
+            } else {
+                max = mid-1;
+            }
+        }
+        return checkpoints[min].value;
+    }
+
+    /**
+     * @dev `updateValueAtNow` used to update the `balances` map and the
+     *  `totalSupplyHistory`
+     * @param checkpoints The history of data being updated
+     * @param _value The new number of tokens
+     */
+    function updateValueAtNow(Checkpoint[] storage checkpoints, uint _value) internal {
+        if ((checkpoints.length == 0)
+        || (checkpoints[checkpoints.length -1].fromBlock < block.number)) {
+            Checkpoint storage newCheckPoint = checkpoints[checkpoints.length++];
+            newCheckPoint.fromBlock = uint128(block.number);
+            newCheckPoint.value = uint128(_value);
+        } else {
+            Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length-1];
+            oldCheckPoint.value = uint128(_value);
+        }
+    }
+
+    /**
+     * @dev Internal function to determine if an address is a contract
+     * @param _addr The address being queried
+     * @return True if `_addr` is a contract
+     */
+    function isContract(address _addr) internal view returns(bool) {
+        uint size;
+        if (_addr == address(0)){
+            return false;
+        }
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return size>0;
+    }
+
+    /**
+     * @dev Helper function to return a min betwen the two uints
+     */
+    function min(uint a, uint b) internal pure returns (uint) {
+        return a < b ? a : b;
+    }
+
+    /**
+     * @notice The fallback function: If the contract's controller has not been
+     *  set to 0, then the `proxyPayment` method is called which relays the
+     *  ether and creates tokens as described in the token controller contract
+     */
+    function () external payable {
+        require(isContract(controller));
+        require(TokenController(controller).proxyPayment.value(msg.value)(msg.sender));
+    }
+
+//////////
+// Safety Methods
+//////////
+
+    /**
+     * @notice This method can be used by the controller to extract mistakenly
+     *  sent tokens to this contract.
+     * @param _token The address of the token contract that you want to recover
+     *  set to 0 in case you want to extract ether.
+     */
+    function claimTokens(address _token) public onlyController {
+        if (_token == address(0)) {
+            controller.transfer(address(this).balance);
+            return;
+        }
+
+        MiniMeToken token = MiniMeToken(address(uint160(_token)));
+        uint balance = token.balanceOf(address(this));
+        token.transfer(controller, balance);
+        emit ClaimedTokens(_token, controller, balance);
+    }
+
+////////////////
+// Events
+////////////////
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
+    event NewCloneToken(address indexed _cloneToken, uint snapshotBlock);
+    event Approval(
+        address indexed _owner,
+        address indexed _spender,
+        uint256 _amount
+    );
+
+}

--- a/dapps/tests/teller-contracts/contracts/token/MiniMeTokenFactory.sol
+++ b/dapps/tests/teller-contracts/contracts/token/MiniMeTokenFactory.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.5.7;
+
+import "./TokenFactory.sol";
+import "./MiniMeToken.sol";
+
+////////////////
+// MiniMeTokenFactory
+////////////////
+
+/**
+ * @dev This contract is used to generate clone contracts from a contract.
+ *  In solidity this is the way to create a contract from a contract of the
+ *  same class
+ */
+contract MiniMeTokenFactory is TokenFactory {
+
+    /**
+     * @notice Update the DApp by creating a new token with new functionalities
+     *  the msg.sender becomes the controller of this clone token
+     * @param _parentToken Address of the token being cloned
+     * @param _snapshotBlock Block of the parent token that will
+     *  determine the initial distribution of the clone token
+     * @param _tokenName Name of the new token
+     * @param _decimalUnits Number of decimals of the new token
+     * @param _tokenSymbol Token Symbol for the new token
+     * @param _transfersEnabled If true, tokens will be able to be transferred
+     * @return The address of the new token contract
+     */
+    function createCloneToken(
+        address _parentToken,
+        uint _snapshotBlock,
+        string memory _tokenName,
+        uint8 _decimalUnits,
+        string memory _tokenSymbol,
+        bool _transfersEnabled
+    ) public returns (address payable) {
+        MiniMeToken newToken = new MiniMeToken(
+            address(this),
+            _parentToken,
+            _snapshotBlock,
+            _tokenName,
+            _decimalUnits,
+            _tokenSymbol,
+            _transfersEnabled
+            );
+
+        newToken.changeController(msg.sender);
+        return address(newToken);
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/token/MiniMeTokenInterface.sol
+++ b/dapps/tests/teller-contracts/contracts/token/MiniMeTokenInterface.sol
@@ -1,0 +1,108 @@
+pragma solidity ^0.5.7;
+
+import "./ERC20Token.sol";
+
+
+contract MiniMeTokenInterface is ERC20Token {
+
+    /**
+     * @notice `msg.sender` approves `_spender` to send `_amount` tokens on
+     *  its behalf, and then a function is triggered in the contract that is
+     *  being approved, `_spender`. This allows users to use their tokens to
+     *  interact with contracts in one function call instead of two
+     * @param _spender The address of the contract able to transfer the tokens
+     * @param _amount The amount of tokens to be approved for transfer
+     * @return True if the function call was successful
+     */
+    function approveAndCall(
+        address _spender,
+        uint256 _amount,
+        bytes memory _extraData
+    ) 
+        public 
+        returns (bool success);
+
+    /**    
+     * @notice Creates a new clone token with the initial distribution being
+     *  this token at `_snapshotBlock`
+     * @param _cloneTokenName Name of the clone token
+     * @param _cloneDecimalUnits Number of decimals of the smallest unit
+     * @param _cloneTokenSymbol Symbol of the clone token
+     * @param _snapshotBlock Block when the distribution of the parent token is
+     *  copied to set the initial distribution of the new clone token;
+     *  if the block is zero than the actual block, the current block is used
+     * @param _transfersEnabled True if transfers are allowed in the clone
+     * @return The address of the new MiniMeToken Contract
+     */
+    function createCloneToken(
+        string memory _cloneTokenName,
+        uint8 _cloneDecimalUnits,
+        string memory _cloneTokenSymbol,
+        uint _snapshotBlock,
+        bool _transfersEnabled
+    ) 
+        public
+        returns(address);
+
+    /**    
+     * @notice Generates `_amount` tokens that are assigned to `_owner`
+     * @param _owner The address that will be assigned the new tokens
+     * @param _amount The quantity of tokens generated
+     * @return True if the tokens are generated correctly
+     */
+    function generateTokens(
+        address _owner,
+        uint _amount
+    )
+        public
+        returns (bool);
+
+    /**
+     * @notice Burns `_amount` tokens from `_owner`
+     * @param _owner The address that will lose the tokens
+     * @param _amount The quantity of tokens to burn
+     * @return True if the tokens are burned correctly
+     */
+    function destroyTokens(
+        address _owner,
+        uint _amount
+    ) 
+        public
+        returns (bool);
+
+    /**        
+     * @notice Enables token holders to transfer their tokens freely if true
+     * @param _transfersEnabled True if transfers are allowed in the clone
+     */
+    function enableTransfers(bool _transfersEnabled) public;
+
+    /**    
+     * @notice This method can be used by the controller to extract mistakenly
+     *  sent tokens to this contract.
+     * @param _token The address of the token contract that you want to recover
+     *  set to 0 in case you want to extract ether.
+     */
+    function claimTokens(address _token) public;
+
+    /**
+     * @dev Queries the balance of `_owner` at a specific `_blockNumber`
+     * @param _owner The address from which the balance will be retrieved
+     * @param _blockNumber The block number when the balance is queried
+     * @return The balance at `_blockNumber`
+     */
+    function balanceOfAt(
+        address _owner,
+        uint _blockNumber
+    ) 
+        public
+        view
+        returns (uint);
+
+    /**
+     * @notice Total amount of tokens at a specific `_blockNumber`.
+     * @param _blockNumber The block number when the totalSupply is queried
+     * @return The total amount of tokens at `_blockNumber`
+     */
+    function totalSupplyAt(uint _blockNumber) public view returns(uint);
+
+}

--- a/dapps/tests/teller-contracts/contracts/token/SafeTransfer.sol
+++ b/dapps/tests/teller-contracts/contracts/token/SafeTransfer.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.5.7;
+
+import "../token/ERC20Token.sol";
+
+
+contract SafeTransfer {
+    function _safeTransfer(ERC20Token _token, address _to, uint256 _value) internal returns (bool result) {
+        _token.transfer(_to, _value);
+        assembly {
+        switch returndatasize()
+            case 0 {
+            result := not(0)
+            }
+            case 32 {
+            returndatacopy(0, 0, 32)
+            result := mload(0)
+            }
+            default {
+            revert(0, 0)
+            }
+        }
+        require(result, "Unsuccessful token transfer");
+    }
+
+    function _safeTransferFrom(
+        ERC20Token _token,
+        address _from,
+        address _to,
+        uint256 _value
+    ) internal returns (bool result)
+    {
+        _token.transferFrom(_from, _to, _value);
+        assembly {
+        switch returndatasize()
+            case 0 {
+            result := not(0)
+            }
+            case 32 {
+            returndatacopy(0, 0, 32)
+            result := mload(0)
+            }
+            default {
+            revert(0, 0)
+            }
+        }
+        require(result, "Unsuccessful token transfer");
+    }
+}

--- a/dapps/tests/teller-contracts/contracts/token/TokenController.sol
+++ b/dapps/tests/teller-contracts/contracts/token/TokenController.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.7;
+/**
+ * @dev The token controller contract must implement these functions
+ */
+interface TokenController {
+    /**
+     * @notice Called when `_owner` sends ether to the MiniMe Token contract
+     * @param _owner The address that sent the ether to create tokens
+     * @return True if the ether is accepted, false if it throws
+     */
+    function proxyPayment(address _owner) external payable returns(bool);
+
+    /**
+     * @notice Notifies the controller about a token transfer allowing the
+     *  controller to react if desired
+     * @param _from The origin of the transfer
+     * @param _to The destination of the transfer
+     * @param _amount The amount of the transfer
+     * @return False if the controller does not authorize the transfer
+     */
+    function onTransfer(address _from, address _to, uint _amount) external returns(bool);
+
+    /**
+     * @notice Notifies the controller about an approval allowing the
+     *  controller to react if desired
+     * @param _owner The address that calls `approve()`
+     * @param _spender The spender in the `approve()` call
+     * @param _amount The amount in the `approve()` call
+     * @return False if the controller does not authorize the approval
+     */
+    function onApprove(address _owner, address _spender, uint _amount) external
+        returns(bool);
+}

--- a/dapps/tests/teller-contracts/contracts/token/TokenFactory.sol
+++ b/dapps/tests/teller-contracts/contracts/token/TokenFactory.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.7;
+
+contract TokenFactory {
+  function createCloneToken(
+          address _parentToken,
+          uint _snapshotBlock,
+          string memory _tokenName,
+          uint8 _decimalUnits,
+          string memory _tokenSymbol,
+          bool _transfersEnabled
+      ) public returns (address payable);
+}

--- a/dapps/tests/teller-contracts/data.js
+++ b/dapps/tests/teller-contracts/data.js
@@ -1,0 +1,369 @@
+/* eslint-disable complexity */
+const async = require('async');
+
+
+module.exports = async (gasPrice, licensePrice, arbitrationLicensePrice, feeMilliPercent, burnAddress, mainnetOwner, fallbackArbitrator, deps) => {
+  try {
+    const networkId = await deps.web3.eth.net.getId();
+
+    const estimateAndSend = (from, gasPrice) => async (toSend, value = 0) => {
+      const estimatedGas = await toSend.estimateGas({from, value});
+      // Don't know why, in the simulator, it fails with a small gas limit
+      const additionalGas = networkId === 1337 ? 20000 : 2000;
+      return toSend.send({from, gasPrice, value, gas: estimatedGas + additionalGas});
+    };
+
+    const addresses = await deps.web3.eth.getAccounts();
+    const main = addresses[0];
+    const sendTrxAccount0 = estimateAndSend(main, gasPrice);
+    const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+    {
+      console.log("Verifying if data script has been run already...");
+      const cVerif = new deps.web3.eth.Contract(deps.contracts.EscrowInstance.options.jsonInterface, deps.contracts.EscrowInstance.options.address);
+      const isInitialized = await cVerif.methods.isInitialized().call();
+      if (isInitialized) {
+        console.log('- Data script already ran once.');
+        console.log('- If you want to run it again (eg you updated the Escrow contract), use `embark reset`');
+        return;
+      }
+    }
+
+    {
+      console.log("Setting RelayHub address in EscrowRelay");
+      let receipt;
+      receipt = await sendTrxAccount0(deps.contracts.EscrowRelay.methods.setRelayHubAddress(deps.contracts.RelayHub.options.address));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    if(networkId === 4 || networkId === 3) {
+      let receipt;
+      console.log("Depositing 0.1 ETH in GSN RelayHub");
+      receipt = await sendTrxAccount0(deps.contracts.RelayHub.methods.depositFor(deps.contracts.EscrowRelay.options.address), deps.web3.utils.toWei("0.1", "ether"));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    if(mainnetOwner){
+      console.log("Setting ownership of 7 contracts");
+      let receipt;
+      receipt = await sendTrxAccount0(deps.contracts.EscrowInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 1/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.SellerLicenseInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 2/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.ArbitrationLicenseInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 3/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.OfferStoreInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 4/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.UserStoreInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 5/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.KyberFeeBurner.methods.transferOwnership(mainnetOwner));
+      console.log('- 6/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.EscrowRelay.methods.transferOwnership(mainnetOwner));
+      console.log('- 7/7: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+    }
+
+
+    {
+      console.log("Setting the initial SellerLicense template calling the init() function");
+      const receipt = await sendTrxAccount0(deps.contracts.SellerLicenseInstance.methods.init(
+        deps.contracts.SNT.options.address,
+        licensePrice,
+        deps.contracts.KyberFeeBurner.options.address
+      ));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+
+    {
+      console.log("Setting the initial ArbitrationLicense template calling the init() function");
+      const receipt = await sendTrxAccount0(deps.contracts.ArbitrationLicenseInstance.methods.init(
+        deps.contracts.SNT.options.address,
+        arbitrationLicensePrice,
+        deps.contracts.KyberFeeBurner.options.address
+      ));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the initial UserStore template calling the init() function");
+      const receipt = await sendTrxAccount0(deps.contracts.UserStoreInstance.methods.init(
+        deps.contracts.SellerLicenseInstance.options.address,
+        deps.contracts.ArbitrationLicenseInstance.options.address
+      ));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the initial OfferStore template calling the init() function");
+      const receipt = await sendTrxAccount0(deps.contracts.OfferStoreInstance.methods.init(
+        deps.contracts.UserStoreInstance.options.address,
+        deps.contracts.SellerLicenseInstance.options.address,
+        deps.contracts.ArbitrationLicenseInstance.options.address,
+        burnAddress,
+        deps.contracts.Medianizer.options.address
+      ));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the initial Escrow template calling the init() function");
+      const receipt = await sendTrxAccount0(deps.contracts.EscrowInstance.methods.init(
+        fallbackArbitrator || main,
+        deps.contracts.EscrowRelay.options.address,
+        deps.contracts.ArbitrationLicenseInstance.options.address,
+        deps.contracts.OfferStoreInstance.options.address,
+        deps.contracts.UserStoreInstance.options.address,
+        deps.contracts.KyberFeeBurner.options.address, // TODO: replace with StakingPool address
+        feeMilliPercent
+      ));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the Offer store proxy address in UserStore");
+      const receipt = await sendTrxAccount0(deps.contracts.UserStoreInstance.methods.setAllowedContract(deps.contracts.OfferStoreInstance.options.address, true));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the escrow proxy address in UserStore");
+      const receipt = await sendTrxAccount0(deps.contracts.UserStoreInstance.methods.setAllowedContract(deps.contracts.EscrowInstance.options.address, true));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the escrow proxy address in OfferStore");
+      const receipt = await sendTrxAccount0(deps.contracts.OfferStoreInstance.methods.setAllowedContract(deps.contracts.EscrowInstance.options.address, true));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the EscrowRelay address in UserStore");
+      const receipt = await sendTrxAccount0(deps.contracts.UserStoreInstance.methods.setAllowedContract(deps.contracts.EscrowRelay.options.address, true));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+    {
+      console.log("Setting the EscrowRelay address in OfferStore");
+      const receipt = await sendTrxAccount0(deps.contracts.OfferStoreInstance.methods.setAllowedContract(deps.contracts.EscrowRelay.options.address, true));
+      console.log((receipt.status === true || receipt.status === 1) ? '- Success' : '- FAILURE!!!');
+    }
+
+
+    if(mainnetOwner){
+      console.log("Setting ownership of 5 proxy");
+      let receipt;
+      receipt = await sendTrxAccount0(deps.contracts.EscrowInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 1/5: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.SellerLicenseInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 2/5: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.ArbitrationLicenseInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 3/5: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.OfferStoreInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 4/5: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+      receipt = await sendTrxAccount0(deps.contracts.UserStoreInstance.methods.transferOwnership(mainnetOwner));
+      console.log('- 4/5: ' + ((receipt.status === true || receipt.status === 1) ? 'Success' : 'FAILURE!!!'));
+    }
+
+    if(networkId === 1 || networkId === 4 || networkId === 3) {
+      console.log("DONE ======================================================================================================");
+
+      const rhBalance = await deps.contracts.RelayHub.methods.balanceOf(deps.contracts.EscrowRelay.options.address).call();
+      console.log(`- The GSN Balance for EscrowRelay is ${rhBalance} wei`);
+      console.log("- Deposit some ETH on GSN relay with:");
+      console.log(`> RelayHub.methods.depositFor(EscrowRelay.options.address).send({value: web3.utils.toWei("0.01", "ether")})`);
+      return;
+    }
+
+
+    // Seeding data only on dev environment
+
+    console.log("Seeding data...");
+
+    const arbitrator = addresses[9];
+
+    const sntToken = 10000000;
+
+    console.log('Send ETH...');
+    const value = 100 * Math.pow(10, 18);
+    let startNonce = await deps.web3.eth.getTransactionCount(main, undefined);
+    try {
+    await Promise.all(addresses.slice(1, 10).map(async (address, idx) => {
+      return deps.web3.eth.sendTransaction({
+        to: address,
+        from: main,
+        value: value.toString(),
+        nonce: startNonce + idx,
+        gas: 21000
+      });
+    }));
+  } catch(ex){
+    console.log(ex);
+    return;
+  }
+
+    console.log('Generate SNT...');
+    await async.eachLimit(addresses, 1, async (address) => {
+        const generateToken = deps.contracts.SNT.methods.generateTokens(address, sntToken + '000000000000000000');
+        const gas = await generateToken.estimateGas({from: main});
+        return generateToken.send({from: main, gas});
+    });
+
+    console.log('Generate Standard Tokens');
+    const weiToken = "5000000000000";
+    await async.eachLimit(addresses.slice(0, 9), 1, async (address) => {
+      const generateToken = deps.contracts.StandardToken.methods.mint(address, weiToken.toString());
+      const gas = await generateToken.estimateGas({from: main});
+      return generateToken.send({from: main, gas});
+    });
+
+    console.log("Buy arbitration licenses");
+    {
+      const buyLicense = deps.contracts.ArbitrationLicenseInstance.methods.buy().encodeABI();
+
+      const sendTrxAccountArbi = estimateAndSend(arbitrator, gasPrice);
+      const sendTrxAccount8 = estimateAndSend(addresses[8], gasPrice);
+
+      await sendTrxAccountArbi(deps.contracts.SNT.methods.approveAndCall(deps.contracts.ArbitrationLicenseInstance._address, arbitrationLicensePrice, buyLicense));
+      await sendTrxAccountArbi(deps.contracts.UserStoreInstance.methods.addOrUpdateUser(CONTACT_DATA, "Montreal", "Fake Arbitrator"));
+
+      await sendTrxAccount8(deps.contracts.SNT.methods.approveAndCall(deps.contracts.ArbitrationLicenseInstance._address, arbitrationLicensePrice, buyLicense));
+
+      // Accepting everyone
+      await sendTrxAccountArbi(deps.contracts.ArbitrationLicenseInstance.methods.changeAcceptAny(true));
+    }
+
+    console.log('Buy Licenses...');
+    const buyLicense = deps.contracts.SellerLicenseInstance.methods.buy().encodeABI();
+    await async.eachLimit(addresses.slice(1, 7), 1, async (address) => {
+      const sendTrxAccount = estimateAndSend(address, gasPrice);
+      return sendTrxAccount(deps.contracts.SNT.methods.approveAndCall(deps.contracts.SellerLicenseInstance._address, licensePrice, buyLicense));
+    });
+
+    console.log('Generating Offers...');
+    const tokens = [deps.contracts.SNT._address, '0x0000000000000000000000000000000000000000'];
+    const paymentMethods = [1, 2, 3];
+    const usernames = ['Jonathan', 'Iuri', 'Anthony', 'Barry', 'Richard', 'Ricardo'];
+    const locations = ['London', 'Montreal', 'Paris', 'Berlin'];
+    const currencies = ['USD', 'EUR'];
+    const offerStartIndex = 1;
+
+    const offerReceipts = await async.mapLimit(addresses.slice(offerStartIndex, offerStartIndex + 5), 1, async (address) => {
+      const sendTrxAccount = estimateAndSend(address, gasPrice);
+
+      const amountToStake = await deps.contracts.OfferStoreInstance.methods.getAmountToStake(address).call();
+
+      return sendTrxAccount(deps.contracts.OfferStoreInstance.methods.addOffer(
+        tokens[1],
+        // TODO un hardcode token and add `approve` in the escrow creation below
+        // tokens[Math.floor(Math.random() * tokens.length)],
+        'Status:' + address, // Cannot use the utils function, because it uses imports and exports which are not supported by Node 10
+        locations[Math.floor(Math.random() * locations.length)],
+        currencies[Math.floor(Math.random() * currencies.length)],
+        usernames[Math.floor(Math.random() * usernames.length)],
+        [paymentMethods[Math.floor(Math.random() * paymentMethods.length)]],
+        0,
+        0,
+        Math.floor(Math.random() * 100),
+        arbitrator
+      ), amountToStake);
+    });
+
+    console.log('Creating escrows and rating them...');
+    const val = 1000;
+    const feeAmount = Math.round(val * (feeMilliPercent / (100 * 1000)));
+
+    const buyerAddress = addresses[offerStartIndex];
+    const escrowStartIndex = offerStartIndex + 1;
+    let receipt, hash, signature, nonce, created, escrowId;
+
+    await async.eachOfLimit(addresses.slice(escrowStartIndex, escrowStartIndex + 1), 1, async (creatorAddress, idx) => {
+      const ethOfferId = offerReceipts[idx - offerStartIndex + escrowStartIndex].events.OfferAdded.returnValues.offerId;
+      // TODO when we re-enable creating tokens too, use this to know
+      // const token = offerReceipts[idx - offerStartIndex + escrowStartIndex].events.OfferAdded.returnValues.asset;
+
+      // Create
+      hash = await deps.contracts.UserStoreInstance.methods.getDataHash(usernames[offerStartIndex], CONTACT_DATA).call({from: buyerAddress});
+      signature = await deps.web3.eth.sign(hash, buyerAddress);
+      nonce = await deps.contracts.UserStoreInstance.methods.user_nonce(buyerAddress).call();
+
+      const sendTrxAccount = estimateAndSend(creatorAddress, gasPrice);
+
+      receipt = await sendTrxAccount(deps.contracts.EscrowInstance.methods.createEscrow(ethOfferId, val, 140, creatorAddress, CONTACT_DATA, locations[offerStartIndex], usernames[offerStartIndex], nonce, signature));
+
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+
+      // Fund
+      receipt = await sendTrxAccount(deps.contracts.EscrowInstance.methods.fund(escrowId), val + feeAmount);
+
+      // Release
+      receipt = await sendTrxAccount(deps.contracts.EscrowInstance.methods.release(escrowId));
+
+      // Rate
+      const rating = Math.floor(Math.random() * 5) + 1;
+      await sendTrxAccount(deps.contracts.EscrowInstance.methods.rateTransaction(escrowId, rating));
+    });
+
+    const sendTrxAccountBuyer = estimateAndSend(buyerAddress, gasPrice);
+    console.log('Creating arbitrations');
+    await async.eachOfLimit(addresses.slice(escrowStartIndex, 5), 1, async (creatorAddress, idx) => {
+      const sendTrxAccount = estimateAndSend(creatorAddress, gasPrice);
+      const ethOfferId = offerReceipts[idx - offerStartIndex + escrowStartIndex].events.OfferAdded.returnValues.offerId;
+      let receipt;
+
+      hash = await deps.contracts.UserStoreInstance.methods.getDataHash(usernames[offerStartIndex], CONTACT_DATA).call({from: buyerAddress});
+      signature = await deps.web3.eth.sign(hash, buyerAddress);
+      nonce = await deps.contracts.UserStoreInstance.methods.user_nonce(buyerAddress).call();
+
+      receipt = await sendTrxAccount(deps.contracts.EscrowInstance.methods.createEscrow(ethOfferId, val, 140, creatorAddress, CONTACT_DATA, locations[offerStartIndex], usernames[offerStartIndex], nonce, signature));
+
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+
+      // Fund
+      await sendTrxAccount(deps.contracts.EscrowInstance.methods.fund(escrowId), val + feeAmount);
+
+      // Buyer pays
+      await sendTrxAccountBuyer(deps.contracts.EscrowInstance.methods.pay(escrowId));
+
+      // Open case
+      await sendTrxAccountBuyer(deps.contracts.EscrowInstance.methods.openCase(escrowId, '1'));
+    });
+
+    const accounts = await async.mapLimit(addresses, 1, async (address) => {
+      const ethBalance = await deps.web3.eth.getBalance(address);
+      const sntBalance = await deps.contracts.SNT.methods.balanceOf(address).call();
+      const isLicenseOwner = await deps.contracts.SellerLicenseInstance.methods.isLicenseOwner(address).call();
+      let offers = [];
+      const user = await deps.contracts.UserStoreInstance.methods.users(address).call();
+      if (user) {
+        const offerIds = await deps.contracts.OfferStoreInstance.methods.getOfferIds(address).call();
+        offers = await Promise.all(offerIds.map(async(offerId) => (
+          deps.contracts.OfferStoreInstance.methods.offer(offerId).call()
+        )));
+      }
+      return {
+        address,
+        isLicenseOwner,
+        isUser: !!user,
+        user,
+        offers,
+        ethBalance: deps.web3.utils.fromWei(ethBalance),
+        sntBalance: deps.web3.utils.fromWei(sntBalance)
+      };
+    });
+
+    console.log('Summary:');
+    console.log('######################');
+    accounts.forEach((account) => {
+      console.log(`Address: ${account.address}:`);
+      console.log(`License Owner: ${account.isLicenseOwner} ETH: ${account.ethBalance} SNT: ${account.sntBalance}`);
+      console.log(`Is User: ${account.isUser} Username: ${account.user.username || 'N/A'} Offers: ${account.offers.length}`);
+      console.log('');
+    });
+  } catch (e) {
+    console.log("------- data seeding error ------- ");
+    console.dir(e);
+  }
+};

--- a/dapps/tests/teller-contracts/embark.json
+++ b/dapps/tests/teller-contracts/embark.json
@@ -1,0 +1,23 @@
+{
+  "contracts": ["contracts/**"],
+  "app": {},
+  "buildDir": "build/",
+  "config": {
+    "contracts": "contracts.js",
+    "blockchain": false,
+    "storage": false,
+    "communication": false,
+    "webserver": false
+  },
+  "versions": {
+    "solc": "0.5.16"
+  },
+  "plugins": {
+  },
+  "options": {
+    "solc": {
+      "optimize": true,
+      "optimize-runs": 200
+    }
+  }
+}

--- a/dapps/tests/teller-contracts/package.json
+++ b/dapps/tests/teller-contracts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "embark-dapp-test-teller-contracts",
+  "description": "Test Teller contracts for integration testing purposes",
+  "version": "5.2.0-nightly.1",
+  "scripts": {
+    "ci": "npm run qa",
+    "clean": "npm run reset",
+    "qa": "npm run test",
+    "reset": "npx embark-reset && npx rimraf embark-*.tgz package",
+    "test": "npx embark test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "embark": "^5.2.0-nightly.3",
+    "embark-reset": "^5.1.1",
+    "rimraf": "3.0.0"
+  }
+}

--- a/dapps/tests/teller-contracts/package.json
+++ b/dapps/tests/teller-contracts/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "embark": "^5.2.0-nightly.3",
-    "embark-reset": "^5.1.1",
+    "embark": "^5.2.4-nightly.0",
+    "embark-reset": "^5.2.3",
     "rimraf": "3.0.0"
   }
 }

--- a/dapps/tests/teller-contracts/test/arbitration_spec.js
+++ b/dapps/tests/teller-contracts/test/arbitration_spec.js
@@ -1,0 +1,294 @@
+/*global contract, config, it, assert, web3, before, describe, beforeEach, artifacts*/
+/* eslint require-atomic-updates:0, no-await-in-loop:0*/
+const TestUtils = require("../utils/testUtils");
+
+const Escrow = artifacts.require('Escrow');
+const ArbitrationLicense = artifacts.require('ArbitrationLicense');
+const OfferStore = artifacts.require('OfferStore');
+const SNT = artifacts.require('SNT');
+
+let accounts;
+let arbitrator, arbitrator2, blacklistedAccount;
+
+const feePercent = 1;
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+config({
+  blockchain: {
+    // The order here corresponds to the order of `web3.eth.getAccounts`, so the first one is the `defaultAccount`
+    accounts: [
+      {
+        mnemonic: "foster gesture flock merge beach plate dish view friend leave drink valley shield list enemy",
+        balance: "5 ether",
+        numAddresses: "10"
+      }
+    ]
+  },
+  contracts: {
+    deploy: {
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        deploy: false
+      },
+      ArbitrationLicense: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+
+      /*
+      StakingPool: {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: ["$SNT"]
+      },
+      */
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      Medianizer: {
+
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"],
+        onDeploy: ["UserStore.methods.setAllowedContract('$OfferStore', true).send()"]
+      },
+      Escrow: {
+        args: ["$accounts[0]", "0x0000000000000000000000000000000000000000", "$ArbitrationLicense", "$OfferStore", "$UserStore", BURN_ADDRESS, feePercent * 1000],
+        onDeploy: [
+          "OfferStore.methods.setAllowedContract('$Escrow', true).send()",
+          "UserStore.methods.setAllowedContract('$Escrow', true).send()"
+        ]
+      },
+      StandardToken: {}
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+  arbitrator = accounts[8];
+  arbitrator2 = accounts[9];
+  blacklistedAccount = accounts[5];
+});
+
+contract("Escrow", function() {
+
+  const tradeAmount = 100;
+  const feeAmount = Math.round(tradeAmount * (feePercent / 100));
+
+  let receipt, escrowId, ethOfferId;
+  let created;
+
+  this.timeout(0);
+
+  before(async () => {
+    await SNT.methods.generateTokens(accounts[0], 1000).send();
+    await SNT.methods.generateTokens(blacklistedAccount, 1000).send();
+
+    // Register arbitrators
+    await SNT.methods.generateTokens(arbitrator, 1000).send();
+    await SNT.methods.generateTokens(arbitrator2, 1000).send();
+
+    const encodedCall2 = ArbitrationLicense.methods.buy().encodeABI();
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator2});
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator});
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator2});
+    await ArbitrationLicense.methods.blacklistSeller(blacklistedAccount).send({from: arbitrator});
+
+    const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+
+    receipt  = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
+  });
+
+  describe("Arbitrations", async() => {
+    beforeEach(async() => {
+      // Create
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U").send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+    });
+
+    it("should allow a buyer to open a case", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+
+      receipt = await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+      const arbitrationRequired = receipt.events.ArbitrationRequired;
+      assert(!!arbitrationRequired, "ArbitrationRequired() not triggered");
+      assert.equal(arbitrationRequired.returnValues.escrowId, escrowId, "Invalid escrowId");
+    });
+
+    it("random account cannot open a case for an existing escrow", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+
+      try {
+        await Escrow.methods.openCase(escrowId, '1').send({from: accounts[3]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only participants can invoke this function");
+      }
+    });
+
+    it("should allow anyone to open an arbitration case on behalf of a buyer", async() => {
+      let messageToSign, signature;
+
+      // Create
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U").send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      messageToSign = await Escrow.methods.paySignHash(escrowId).call();
+      signature = await web3.eth.sign(messageToSign, accounts[1]);
+
+      receipt = await Escrow.methods['pay(uint256,bytes)'](escrowId, signature).send({from: accounts[8]});
+
+      messageToSign = await Escrow.methods.openCaseSignHash(escrowId, "1").call();
+      signature = await web3.eth.sign(messageToSign, accounts[1]);
+
+      receipt = await Escrow.methods['openCase(uint256,uint8,bytes)'](escrowId, "1", signature).send({from: accounts[9]});
+      const arbitrationRequired = receipt.events.ArbitrationRequired;
+      assert(!!arbitrationRequired, "ArbitrationRequired() not triggered");
+      assert.equal(arbitrationRequired.returnValues.escrowId, escrowId, "Invalid escrowId");
+    });
+
+    const ARBITRATION_SOLVED_BUYER = 1;
+    const ARBITRATION_SOLVED_SELLER = 2;
+
+    it("non arbitrators cannot resolve a case", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      try {
+        receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_BUYER).send({from: accounts[1]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only arbitrators can invoke this function");
+      }
+    });
+
+    it("non selected arbitrator cannot resolve a case", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      try {
+        receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_BUYER).send({from: arbitrator2});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        TestUtils.assertJump(error);
+      }
+    });
+
+    it("should allow whoever opened an arbitration to cancel it", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      receipt = await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      try {
+        receipt = await Escrow.methods.cancelArbitration(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Arbitration can only be canceled by the opener");
+      }
+
+      receipt = await Escrow.methods.cancelArbitration(escrowId).send({from: accounts[1]});
+      const arbitrationCanceled = receipt.events.ArbitrationCanceled;
+      assert(!!arbitrationCanceled, "ArbitrationCanceled() not triggered");
+      assert.strictEqual(arbitrationCanceled.returnValues.escrowId, escrowId, "Invalid escrowId");
+    });
+
+    it("should transfer to buyer if case is solved in their favor", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_BUYER).send({from: arbitrator});
+      const released = receipt.events.Released;
+      assert(!!released, "Released() not triggered");
+    });
+
+    it("should cancel escrow if case is solved in favor of the seller", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_SELLER).send({from: arbitrator});
+
+      const released = receipt.events.Canceled;
+      assert(!!released, "Canceled() not triggered");
+    });
+
+    it("cannot cancel a solved arbitration", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      receipt = await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+      receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_SELLER).send({from: arbitrator});
+
+      try {
+        receipt = await Escrow.methods.cancelArbitration(escrowId).send({from: accounts[1]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Arbitration already solved or not open");
+      }
+    });
+
+    it("can open an arbitration on a escrow that had a canceled arbitration before", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      receipt = await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+      receipt = await Escrow.methods.cancelArbitration(escrowId).send({from: accounts[1]});
+      receipt = await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+      const arbitrationRequired = receipt.events.ArbitrationRequired;
+      assert(!!arbitrationRequired, "ArbitrationRequired() not triggered");
+    });
+
+    it("arbitrator should be valid", async () => {
+      const isArbitrator = await ArbitrationLicense.methods.isLicenseOwner(arbitrator).call();
+      assert.equal(isArbitrator, true, "Invalid arbitrator");
+
+      const nonArbitrator = await ArbitrationLicense.methods.isLicenseOwner(accounts[5]).call();
+      assert.equal(nonArbitrator, false, "Account should not be an arbitrator");
+    });
+
+    it("should not be able to rate an open dispute", async() => {
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      try {
+        await Escrow.methods.rateTransaction(escrowId, 2).send({from: accounts[1]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Transaction not completed yet");
+      }
+
+      receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_BUYER).send({from: arbitrator});
+
+      await Escrow.methods.rateTransaction(escrowId, 2).send({from: accounts[1]});
+    });
+
+    it('should not allow a blacklisted seller to open an offer', async () => {
+      try {
+        const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+        await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: blacklistedAccount, value: amountToStake});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Arbitrator does not allow this transaction");
+      }
+    });
+  });
+
+});

--- a/dapps/tests/teller-contracts/test/escrow_spec.js
+++ b/dapps/tests/teller-contracts/test/escrow_spec.js
@@ -1,0 +1,788 @@
+/*global contract, config, it, assert, web3, before, describe, beforeEach, increaseTime, artifacts*/
+/* eslint require-atomic-updates:0, no-await-in-loop:0*/
+const TestUtils = require("../utils/testUtils");
+
+const ArbitrationLicense = artifacts.require('ArbitrationLicense');
+const UserStore = artifacts.require('UserStore');
+const OfferStore = artifacts.require('OfferStore');
+const Escrow = artifacts.require('Escrow');
+const StandardToken = artifacts.require('StandardToken');
+const SNT = artifacts.require('SNT');
+
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+const ESCROW_CREATED = '0';
+const ESCROW_FUNDED = '1';
+const ESCROW_RELEASED = '3';
+const ESCROW_CANCELED = '4';
+
+let accounts;
+let arbitrator, arbitrator2;
+
+const feePercent = 1;
+
+config({
+  blockchain: {
+    accounts: [
+      {
+        mnemonic: "foster gesture flock merge beach plate dish view friend leave drink valley shield list enemy",
+        balance: "5 ether",
+        numAddresses: "10"
+      }
+    ]
+  },
+  contracts: {
+    deploy: {
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        deploy: false
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+      ArbitrationLicense: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      Medianizer: {
+
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"],
+        onDeploy: ["UserStore.methods.setAllowedContract('$OfferStore', true).send()"]
+      },
+      Escrow: {
+        args: ["$accounts[0]", "0x0000000000000000000000000000000000000000", "$ArbitrationLicense", "$OfferStore", "$UserStore", BURN_ADDRESS, feePercent * 1000]
+      },
+      StandardToken: {}
+    }
+  }
+}, (_err, web3_accounts) => {
+  web3.eth.defaultAccount = web3_accounts[0];
+  accounts = web3_accounts;
+  arbitrator = accounts[8];
+  arbitrator2 = accounts[9];
+});
+
+contract("Escrow", function() {
+
+  const {toBN} = web3.utils;
+
+  const tradeAmount = 1000000;
+  const feeAmount = Math.round(tradeAmount * (feePercent / 100));
+
+  // util
+  const expireTransaction = async() => {
+    const addTime = 5 * 86400;
+    try {
+      await increaseTime(addTime + 1);
+    } catch (e) {
+      console.error('Error with the increase time', e);
+    }
+  };
+
+  let receipt, escrowId, escrowTokenId, sntOfferId, ethOfferId, tokenOfferId, hash, signature, nonce;
+  let created;
+
+  this.timeout(0);
+
+  before(async () => {
+    await OfferStore.methods.setAllowedContract(Escrow.options.address, true).send();
+    await UserStore.methods.setAllowedContract(Escrow.options.address, true).send();
+
+    await SNT.methods.generateTokens(accounts[0], 1000).send();
+
+    // Register arbitrators
+    await SNT.methods.generateTokens(arbitrator, 1000).send();
+    await SNT.methods.generateTokens(arbitrator2, 1000).send();
+
+    const encodedCall2 = ArbitrationLicense.methods.buy().encodeABI();
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator2});
+
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator});
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator2});
+
+    let amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    receipt  = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
+
+    amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    receipt  = await OfferStore.methods.addOffer(StandardToken.options.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    tokenOfferId = receipt.events.OfferAdded.returnValues.offerId;
+
+    amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    receipt  = await OfferStore.methods.addOffer(SNT.options.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    sntOfferId = receipt.events.OfferAdded.returnValues.offerId;
+  });
+
+  describe("Creating a new escrow", async () => {
+    it("Buyer can create escrow", async () => {
+      receipt = await Escrow.methods.createEscrow(ethOfferId, 123, 140, accounts[1], CONTACT_DATA, "L", "Username").send({from: accounts[1]});
+
+      const created = receipt.events.Created;
+      assert(!!created, "Created() not triggered");
+      assert.strictEqual(created.returnValues.offerId, ethOfferId, "Invalid offerId");
+      assert.strictEqual(created.returnValues.buyer, accounts[1], "Invalid buyer");
+    });
+
+    it("Buyer can create escrow using signature", async () => {
+      hash = await UserStore.methods.getDataHash("Username", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.createEscrow(ethOfferId, 123, 140, accounts[1], CONTACT_DATA, "L", "Username", nonce, signature).send({from: accounts[1]});
+
+      const created = receipt.events.Created;
+      assert(!!created, "Created() not triggered");
+      assert.strictEqual(created.returnValues.offerId, ethOfferId, "Invalid offerId");
+      assert.strictEqual(created.returnValues.buyer, accounts[1], "Invalid buyer");
+    });
+
+    it("Seller should be able to create escrows", async () => {
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.createEscrow(ethOfferId, 123, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[0]});
+
+      const created = receipt.events.Created;
+      assert(!!created, "Created() not triggered");
+
+      assert.strictEqual(created.returnValues.offerId, ethOfferId, "Invalid offerId");
+      assert.strictEqual(created.returnValues.buyer, accounts[1], "Invalid buyer");
+      escrowId = created.returnValues.escrowId;
+    });
+
+    it("Created escrow should contain valid data", async () => {
+      const escrow = await Escrow.methods.transactions(escrowId).call();
+
+      assert.strictEqual(escrow.offerId, ethOfferId, "Invalid offerId");
+      assert.strictEqual(escrow.buyer, accounts[1], "Invalid buyer");
+      assert.strictEqual(escrow.tokenAmount, "123", "Invalid trade amount");
+      assert.strictEqual(escrow.status, ESCROW_CREATED, "Invalid status");
+    });
+
+    it("Seller should be able to fund escrow", async () => {
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[0], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[0]});
+      escrowId = receipt.events.Created.returnValues.escrowId;
+
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+      const funded = receipt.events.Funded;
+      assert(!!funded, "Funded() not triggered");
+    });
+
+    it("Funded escrow should contain valid data", async () => {
+      const ethFeeBalance = await Escrow.methods.feeTokenBalances(TestUtils.zeroAddress).call();
+      assert.strictEqual(parseInt(ethFeeBalance, 10), feeAmount, 'Invalid fee balance');
+      const contractBalance = await web3.eth.getBalance(Escrow.options.address);
+      assert.strictEqual(parseInt(contractBalance, 10), feeAmount + tradeAmount, "Invalid contract balance");
+      const escrow = await Escrow.methods.transactions(escrowId).call();
+      assert.strictEqual(parseInt(escrow.tokenAmount, 10), tradeAmount, "Invalid amount");
+      assert.strictEqual(escrow.status, ESCROW_FUNDED, "Invalid status");
+    });
+
+    it("Escrows can be created with ERC20 tokens", async () => {
+      await StandardToken.methods.mint(accounts[0], tradeAmount + feeAmount).send();
+
+      const balanceBeforeCreation = await StandardToken.methods.balanceOf(accounts[0]).call();
+
+      await StandardToken.methods.approve(Escrow.options.address, tradeAmount + feeAmount).send({from: accounts[0]});
+      const allowance = await StandardToken.methods.allowance(accounts[0], Escrow.options.address).call();
+      assert(allowance >= tradeAmount + feeAmount, "Allowance needs to be equal or higher to the amount plus the fee");
+
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.createEscrow(tokenOfferId, tradeAmount, 140, accounts[0], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[0]});
+      const created = receipt.events.Created;
+      assert(!!created, "Created() not triggered");
+      escrowTokenId = receipt.events.Created.returnValues.escrowId;
+
+      receipt = await Escrow.methods.fund(escrowTokenId).send({from: accounts[0]});
+      const funded = receipt.events.Funded;
+      assert(!!funded, "Funded() not triggered");
+
+      const balanceAfterCreation = await StandardToken.methods.balanceOf(accounts[0]).call();
+
+      assert(toBN(balanceAfterCreation), toBN(balanceBeforeCreation).sub(toBN(tradeAmount)), "Token value wasn't deducted");
+
+      const contractBalance = await StandardToken.methods.balanceOf(Escrow.options.address).call();
+
+      assert(toBN(contractBalance), toBN(tradeAmount), "Contract token balance is incorrect");
+
+      const escrow = await Escrow.methods.transactions(escrowTokenId).call();
+
+      assert.strictEqual(parseInt(escrow.tokenAmount, 10), tradeAmount, "Invalid amount");
+    });
+
+    it("Can fund an SNT escrow with approveAndCall", async () => {
+      await SNT.methods.approve(Escrow.options.address, 0).send({from: accounts[0]});
+
+      await SNT.methods.generateTokens(accounts[0], tradeAmount + feeAmount).send();
+
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      let receipt = await Escrow.methods.createEscrow(sntOfferId, tradeAmount, 140, accounts[0], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[0]});
+      escrowTokenId = receipt.events.Created.returnValues.escrowId;
+
+
+      SNT.options.jsonInterface.push(Escrow.options.jsonInterface.find(x => x.name === 'Funded'));
+      const encodedCall = Escrow.methods.fund(escrowTokenId).encodeABI();
+      receipt = await SNT.methods.approveAndCall(Escrow.options.address, tradeAmount + feeAmount, encodedCall).send({from: accounts[0]});
+
+      const funded = receipt.events.Funded;
+      assert(!!funded, "Funded() not triggered");
+
+    });
+  });
+
+
+  describe("Canceling an escrow", async () => {
+    it("A seller cannot cancel an unexpired funded escrow", async () => {
+      // Create and Fund
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createAndFund(ethOfferId, tradeAmount, 140, CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[0], value: tradeAmount + feeAmount});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+
+      try {
+        receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Can only be canceled after expiration");
+      }
+    });
+
+    it("A seller can cancel their ETH escrows", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      await expireTransaction();
+
+      receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+
+      let Canceled = receipt.events.Canceled;
+      assert(!!Canceled, "Canceled() not triggered");
+
+      let escrow = await Escrow.methods.transactions(escrowId).call();
+      assert.strictEqual(escrow.status, ESCROW_CANCELED, "Should have been canceled");
+    });
+
+    it("A seller can cancel their expired token escrows and gets back the fee", async () => {
+      await StandardToken.methods.mint(accounts[0], tradeAmount + feeAmount).send();
+      await StandardToken.methods.approve(Escrow.options.address, tradeAmount + feeAmount).send({from: accounts[0]});
+
+      const balanceBeforeCreation = await StandardToken.methods.balanceOf(accounts[0]).call();
+      const contractBalanceBeforeCreation = await StandardToken.methods.balanceOf(Escrow.options.address).call();
+
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(tokenOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowTokenId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowTokenId).send({from: accounts[0]});
+
+      await expireTransaction();
+
+      await Escrow.methods.cancel(escrowTokenId).send({from: accounts[0]});
+
+      const balanceAfterCancelation = await StandardToken.methods.balanceOf(accounts[0]).call();
+      const contractBalanceAfterCancelation = await StandardToken.methods.balanceOf(Escrow.options.address).call();
+
+      let escrow = await Escrow.methods.transactions(escrowTokenId).call();
+
+      assert.strictEqual(escrow.status, ESCROW_CANCELED, "Should have been canceled");
+      assert.strictEqual(balanceBeforeCreation, balanceAfterCancelation, "Invalid seller balance");
+      assert.strictEqual(contractBalanceBeforeCreation, contractBalanceAfterCancelation, "Invalid contract balance");
+    });
+
+    it("A buyer can cancel an escrow that hasn't been funded yet", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[1]});
+      let Canceled = receipt.events.Canceled;
+      assert(!!Canceled, "Canceled() not triggered");
+    });
+
+    it("A buyer can cancel an escrow that has been funded", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[1]});
+      let Canceled = receipt.events.Canceled;
+      assert(!!Canceled, "Canceled() not triggered");
+    });
+
+    it("An escrow can only be canceled once", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      await expireTransaction();
+      receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+
+      try {
+        receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only transactions in created or funded state can be canceled");
+      }
+    });
+
+    it("Accounts different from the escrow owner cannot cancel escrows", async() => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      try {
+        receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[2]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only participants can invoke this function");
+      }
+    });
+
+    it("A seller cannot cancel an escrow marked as paid", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      receipt = await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+
+      try {
+        receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only transactions in created or funded state can be canceled");
+      }
+    });
+  });
+
+
+  describe("Releasing escrows", async () => {
+    beforeEach(async() => {
+      await StandardToken.methods.mint(accounts[0], tradeAmount + feeAmount).send();
+
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+    });
+
+    it("An invalid escrow cannot be released", async() => {
+      try {
+        await Escrow.methods.release(999).send({from: accounts[0]}); // Invalid escrow
+        assert.fail('should have reverted before');
+      } catch (error) {
+        TestUtils.assertJump(error);
+      }
+    });
+
+    it("Accounts different from the seller cannot release an escrow", async () => {
+      try {
+        await Escrow.methods.release(escrowId).send({from: accounts[1]}); // Buyer tries to release
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only the seller can invoke this function");
+      }
+    });
+
+    it("Escrow owner can release his funds to the buyer", async () => {
+      const buyerBalanceBeforeEscrow = await web3.eth.getBalance(accounts[1]);
+      receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
+      const buyerBalanceAfterEscrow = await web3.eth.getBalance(accounts[1]);
+
+      const released = receipt.events.Released;
+      assert(!!released, "Released() not triggered");
+
+      const escrow = await Escrow.methods.transactions(escrowId).call();
+      assert.strictEqual(escrow.status, ESCROW_RELEASED, "Should have been released");
+      assert.strictEqual(toBN(escrow.tokenAmount).add(toBN(buyerBalanceBeforeEscrow)).toString(), buyerBalanceAfterEscrow.toString(), "Invalid buyer balance");
+    });
+
+    it("Escrow owner can release token funds to the buyer", async () => {
+      await StandardToken.methods.approve(Escrow.options.address, tradeAmount + feeAmount).send({from: accounts[0]});
+
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(tokenOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowTokenId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowTokenId).send({from: accounts[0]});
+
+      const buyerBalanceBeforeEscrow = await StandardToken.methods.balanceOf(accounts[1]).call();
+      const contractBalanceBeforeEscrow = await StandardToken.methods.balanceOf(Escrow.options.address).call();
+
+      const escrow = await Escrow.methods.transactions(escrowTokenId).call();
+
+      receipt = await Escrow.methods.release(escrowTokenId).send({from: accounts[0]});
+      const buyerBalanceAfterEscrow = await StandardToken.methods.balanceOf(accounts[1]).call();
+      const contractBalanceAfterEscrow = await StandardToken.methods.balanceOf(Escrow.options.address).call();
+
+      assert.strictEqual(toBN(escrow.tokenAmount).add(toBN(buyerBalanceBeforeEscrow)).toString(), buyerBalanceAfterEscrow.toString(), "Invalid buyer balance");
+      const after = toBN(contractBalanceBeforeEscrow).sub(toBN(tradeAmount).add(toBN(feeAmount)));
+      assert.strictEqual(contractBalanceAfterEscrow.toString(), after.toString(), "Invalid contract balance");
+    });
+
+    it("Escrow funds can be released to different destinations", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[7], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+
+      const buyerBalanceBeforeEscrow = await web3.eth.getBalance(accounts[7]);
+      const escrow = await Escrow.methods.transactions(escrowId).call();
+      receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
+      const buyerBalanceAfterEscrow = await web3.eth.getBalance(accounts[7]);
+
+      assert.equal(toBN(escrow.tokenAmount).add(toBN(buyerBalanceBeforeEscrow)).toString(), buyerBalanceAfterEscrow, "Invalid buyer balance");
+    });
+
+    it("Released escrow cannot be released again", async() => {
+      await Escrow.methods.release(escrowId).send({from: accounts[0]});
+
+      try {
+        receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Invalid transaction status");
+      }
+    });
+
+    it("Released escrow cannot be canceled", async() => {
+      await Escrow.methods.release(escrowId).send({from: accounts[0]});
+
+      try {
+        receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only transactions in created or funded state can be canceled");
+      }
+    });
+
+    it("Canceled escrow cannot be released", async() => {
+      await expireTransaction();
+
+      await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+
+      try {
+        receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Invalid transaction status");
+      }
+    });
+  });
+
+
+  describe("Buyer notifies payment of escrow", async () => {
+    beforeEach(async() => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+    });
+
+    it("A random account should not be able to mark a transaction as paid", async () => {
+      try {
+        receipt = await Escrow.methods.pay(escrowId).send({from: accounts[7]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only the buyer can invoke this function");
+      }
+    });
+
+    it("A buyer should be able to mark an escrow transaction as paid", async () => {
+      receipt = await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+      const paid = receipt.events.Paid;
+      assert(!!paid, "Paid() not triggered");
+      assert.strictEqual(paid.returnValues.escrowId, escrowId, "Invalid escrow id");
+    });
+
+    it("Anyone should be able to mark an escrow transaction as paid on behalf of the buyer", async () => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      escrowId = receipt.events.Created.returnValues.escrowId;
+
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      const messageToSign = await Escrow.methods.paySignHash(escrowId).call();
+      signature = await web3.eth.sign(messageToSign, accounts[1]);
+
+      receipt = await Escrow.methods['pay(uint256,bytes)'](escrowId, signature).send({from: accounts[9]});
+
+      const paid = receipt.events.Paid;
+      assert(!!paid, "Paid() not triggered");
+      assert.strictEqual(paid.returnValues.escrowId, escrowId, "Invalid escrowId");
+    });
+
+    it("A seller cannot cancel paid escrows", async () => {
+      receipt = await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+
+      await expireTransaction();
+
+      try {
+        receipt = await Escrow.methods.cancel(escrowId).send({from: accounts[0]});
+        assert.fail('should have reverted before');
+      } catch (error) {
+        assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Only transactions in created or funded state can be canceled");
+      }
+    });
+  });
+
+  describe("Rating a released Transaction", async() => {
+    beforeEach(async() => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      await Escrow.methods.release(escrowId).send({from: accounts[0]});
+    });
+
+    it("should not allow a score that's less than 1", async() => {
+      try {
+        await Escrow.methods.rateTransaction(escrowId, 0).send({from: accounts[1]});
+        assert.fail('should have reverted: should not allow a score last less than 1');
+      } catch(error) {
+        TestUtils.assertJump(error);
+        assert.ok(error.message.indexOf('Rating needs to be at least 1') >= 0);
+      }
+    });
+
+    it("should not allow a score to be more than 5", async() => {
+      try {
+        await Escrow.methods.rateTransaction(escrowId, 6).send({from: accounts[1]});
+        assert.fail('should have reverted: should not allow a score to be more than 5');
+      } catch(error) {
+        TestUtils.assertJump(error);
+        assert.ok(error.message.indexOf('Rating needs to be at less than or equal to 5'));
+      }
+    });
+
+    for(let i=1; i<=5; i++) {
+      it("should allow a score of " + i, async() => {
+        await Escrow.methods.rateTransaction(escrowId, i).send({from: accounts[1]});
+        const transaction = await Escrow.methods.transactions(escrowId).call();
+        assert.strictEqual(transaction.sellerRating, i.toString());
+      });
+    }
+
+    it("should only allow rating once", async() => {
+      await Escrow.methods.rateTransaction(escrowId, 3).send({from: accounts[1]});
+      let transaction = await Escrow.methods.transactions(escrowId).call();
+      assert.strictEqual(transaction.sellerRating, "3");
+
+      try {
+        await Escrow.methods.rateTransaction(escrowId, 2).send({from: accounts[1]});
+      } catch(error) {
+        TestUtils.assertJump(error);
+        assert.ok(error.message.indexOf('Transaction already rated') >= 0);
+      }
+    });
+
+    it("should allow the buyer to rate the transaction", async() => {
+      receipt = await Escrow.methods.rateTransaction(escrowId, 4).send({from: accounts[0]});
+    });
+
+    it("should allow the seller to rate the transaction", async() => {
+      receipt = await Escrow.methods.rateTransaction(escrowId, 4).send({from: accounts[1]});
+    });
+
+    it("should not allow a random account to rate the transaction", async() => {
+      try {
+        receipt = await Escrow.methods.rateTransaction(escrowId, 4).send({from: accounts[5]});
+        assert.fail('should have reverted: should only allow the buyer to rate the transaction');
+      } catch(error) {
+        TestUtils.assertJump(error);
+        assert.ok(error.message.indexOf('Only participants can invoke this function') >= 0);
+      }
+    });
+  });
+
+  describe("Rating an unreleased Transaction", async() => {
+    let receipt, created, escrowId;
+
+    beforeEach(async() => {
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+    });
+
+    it("should not allow rating an unreleased transaction", async() => {
+      try {
+        await Escrow.methods.rateTransaction(escrowId, 4).send({from: accounts[0]});
+        assert.fail('should have reverted: should not allow a score last less than 1');
+      } catch(error) {
+        TestUtils.assertJump(error);
+        assert.ok(error.message.indexOf('Transaction not completed yet') >= 0);
+      }
+    });
+  });
+
+  describe("Getting a user rating", async() => {
+    let receipt, created, escrowId, seller;
+
+    beforeEach(async() => {
+      seller = accounts[0];
+      for (let i = 1; i <= 5; i++) {
+        let buyer = accounts[i];
+        let rating = i;
+        const isPaused = await Escrow.methods.paused().call();
+        if (isPaused) {
+          receipt = await Escrow.methods.unpause().send({from: seller});
+        }
+
+        // Create
+        hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: buyer});
+        signature = await web3.eth.sign(hash, buyer);
+        nonce = await UserStore.methods.user_nonce(buyer).call();
+        receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: buyer});
+        created = receipt.events.Created;
+        escrowId = created.returnValues.escrowId;
+        // Fund
+        receipt = await Escrow.methods.fund(escrowId).send({from: seller, value: tradeAmount + feeAmount});
+
+        await Escrow.methods.release(escrowId).send({from: seller});
+        await Escrow.methods.rateTransaction(escrowId, rating).send({from: buyer});
+      }
+    });
+
+    it("should calculate the user rating", async() => {
+      const arrAvg = arr => arr.reduce((a,b) => a + b, 0) / arr.length;
+      const events = await Escrow.getPastEvents('Rating', {fromBlock: 1, filter: {seller}});
+
+      let ratings = events.slice(events.length - 5).map((e) => parseInt(e.returnValues.rating, 10));
+      assert.strictEqual(arrAvg(ratings), 3, "The seller rating is not correct");
+    });
+  });
+
+   describe("Escrow fees", async() => {
+    it("fee balance should increase with escrow funding", async() => {
+      const ethFeeBalanceBefore = await Escrow.methods.feeTokenBalances(TestUtils.zeroAddress).call();
+      const totalEthBefore = await web3.eth.getBalance(Escrow.options.address);
+
+      // Create
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+      // Fund
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      const ethFeeBalance = await Escrow.methods.feeTokenBalances(TestUtils.zeroAddress).call();
+      const totalEthAfter = await web3.eth.getBalance(Escrow.options.address);
+
+      assert.strictEqual(parseInt(ethFeeBalance, 10), parseInt(ethFeeBalanceBefore, 10) + feeAmount, "Fee balance did not increase");
+      assert.strictEqual(parseInt(totalEthAfter, 10), parseInt(totalEthBefore, 10) + feeAmount + tradeAmount, "Total balance did not increase");
+    });
+  });
+});

--- a/dapps/tests/teller-contracts/test/escrow_upgradability_spec.js
+++ b/dapps/tests/teller-contracts/test/escrow_upgradability_spec.js
@@ -1,0 +1,157 @@
+/*global contract, config, it, assert, web3, before, describe, artifacts*/
+const TestUtils = require("../utils/testUtils");
+const EscrowInstance = artifacts.require('EscrowInstance');
+const ArbitrationLicense = artifacts.require('ArbitrationLicense');
+const SNT = artifacts.require('SNT');
+const UserStore = artifacts.require('UserStore');
+const OfferStore = artifacts.require('OfferStore');
+const TestEscrowUpgrade = artifacts.require('TestEscrowUpgrade');
+
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+
+let accounts, arbitrator;
+let receipt;
+let ethOfferId;
+
+config({
+  contracts: {
+    deploy: {
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        deploy: false
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      Medianizer: {
+
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"],
+        onDeploy: ["UserStore.methods.setAllowedContract('$OfferStore', true).send()"]
+      },
+      ArbitrationLicense: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+
+      /*
+      StakingPool: {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: ["$SNT"]
+      },
+      */
+
+      Escrow: {
+        args: ["$accounts[0]", "0x0000000000000000000000000000000000000002", "$ArbitrationLicense", "$OfferStore", "$UserStore", BURN_ADDRESS, 1000]
+      },
+      Proxy: {
+        deploy: false
+      },
+      EscrowInstance: {
+        instanceOf: "Proxy",
+        proxyFor: "Escrow",
+        args: ["0x", "$Escrow"]
+      },
+
+      TestEscrowUpgrade: {
+        args: ["$accounts[0]", "0x0000000000000000000000000000000000000002", "$ArbitrationLicense", "$OfferStore", "$UserStore", BURN_ADDRESS, 1000]
+      },
+      StandardToken: {}
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+  arbitrator = accounts[8];
+});
+
+contract("Escrow", function() {
+  this.timeout(0);
+
+  describe("Upgradeable Escrows", async () => {
+
+    before(async () => {
+      await UserStore.methods.setAllowedContract(EscrowInstance.options.address, true).send();
+
+      await OfferStore.methods.setAllowedContract(EscrowInstance.options.address, true).send();
+
+
+      await SNT.methods.generateTokens(accounts[0], 1000).send();
+      await SNT.methods.generateTokens(arbitrator, 1000).send();
+      const encodedCall2 = ArbitrationLicense.methods.buy().encodeABI();
+      await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
+      await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator});
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      receipt  = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
+    });
+
+
+    it("Can create initial escrow version", async () => {
+
+      // Here we are setting the initial "template" by calling the init() function
+      EscrowInstance.methods.init(
+        accounts[0],
+        ArbitrationLicense.options.address, // random address for the relay
+        ArbitrationLicense.options.address,
+        OfferStore.options.address,
+        UserStore.options.address,
+        "0x0000000000000000000000000000000000000002", // TODO: replace by StakingPool address
+        1000
+      ).send({from: accounts[0]});
+
+    });
+
+    it("Can create an escrow", async () => {
+      receipt = await EscrowInstance.methods.createEscrow(ethOfferId, 123, 140, accounts[1], CONTACT_DATA, "L", "U").send({from: accounts[1]});
+      const created = receipt.events.Created;
+      assert(!!created, "Created() not triggered");
+      assert.strictEqual(created.returnValues.offerId, ethOfferId, "Invalid offerId");
+      assert.strictEqual(created.returnValues.buyer, accounts[1], "Invalid buyer");
+    });
+
+    it("Can create an escrow using a signature", async () => {
+      const hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      const signature = await web3.eth.sign(hash, accounts[1]);
+      const nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await EscrowInstance.methods.createEscrow(ethOfferId, 123, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      const created = receipt.events.Created;
+      assert(!!created, "Created() not triggered");
+      assert.strictEqual(created.returnValues.offerId, ethOfferId, "Invalid offerId");
+      assert.strictEqual(created.returnValues.buyer, accounts[1], "Invalid buyer");
+    });
+
+    it("Can upgrade contract", async () => {
+      receipt = await EscrowInstance.methods.updateCode(TestEscrowUpgrade.options.address).send();
+      // eslint-disable-next-line
+      TestEscrowUpgrade.options.address = EscrowInstance.options.address;
+    });
+
+    it("Can call new contract functions", async () => {
+      const val = 5;
+      await TestEscrowUpgrade.methods.setVal(val).send();
+      const currentVal = await TestEscrowUpgrade.methods.getVal().call();
+      assert.strictEqual(val.toString(), currentVal.toString());
+    });
+  });
+});

--- a/dapps/tests/teller-contracts/test/funding_escrows_spec.js
+++ b/dapps/tests/teller-contracts/test/funding_escrows_spec.js
@@ -1,0 +1,282 @@
+/*global contract, config, it, web3, before, describe, beforeEach, artifacts*/
+/* eslint require-atomic-updates:0, no-await-in-loop:0*/
+const TestUtils = require("../utils/testUtils");
+
+const UserStore = artifacts.require('UserStore');
+const OfferStore = artifacts.require('OfferStore');
+const ArbitrationLicense = artifacts.require('ArbitrationLicense');
+const Escrow = artifacts.require('Escrow');
+const StandardToken = artifacts.require('StandardToken');
+const SNT = artifacts.require('SNT');
+
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+let accounts;
+const fundAmount = 100;
+
+const feePercent = 1;
+const feeAmount = Math.round(fundAmount * (feePercent / 100));
+
+config({
+  contracts: {
+    deploy: {
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        deploy: false
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      Medianizer: {
+
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"],
+        onDeploy: ["UserStore.methods.setAllowedContract('$OfferStore', true).send()"]
+      },
+      ArbitrationLicense: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+
+      /*
+      StakingPool: {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: ["$SNT"]
+      },
+      */
+
+      Escrow: {
+        args: ["$accounts[0]", "0x0000000000000000000000000000000000000002", "$ArbitrationLicense", "$OfferStore", "$UserStore", BURN_ADDRESS, feePercent * 1000]
+      },
+      StandardToken: {}
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+});
+
+function sequentialPromiseExec(tasks) {
+  return tasks.reduce((p, task) => p.then(task), Promise.resolve());
+}
+
+contract("Escrow Funding", function() {
+  const {toBN} = web3.utils;
+  const value = fundAmount + feeAmount;
+
+  let receipt, escrowId, ethOfferId, tokenOfferId, SNTOfferId, arbitrator;
+
+  this.timeout(0);
+
+  before(async () => {
+    await StandardToken.methods.mint(accounts[0], 100000000).send();
+    await SNT.methods.generateTokens(accounts[0], 100000000).send();
+
+    // Register arbitrators
+    arbitrator = accounts[9];
+    await SNT.methods.generateTokens(arbitrator, 1000).send();
+    const encodedCall2 = ArbitrationLicense.methods.buy().encodeABI();
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
+
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator});
+
+    let amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    receipt  = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
+
+    amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    receipt  = await OfferStore.methods.addOffer(StandardToken.options.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    tokenOfferId = receipt.events.OfferAdded.returnValues.offerId;
+
+    amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    receipt  = await OfferStore.methods.addOffer(SNT.options.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+    SNTOfferId = receipt.events.OfferAdded.returnValues.offerId;
+  });
+
+  describe("ETH as asset", async () => {
+    beforeEach(async () => {
+
+      const hash = await UserStore.methods.getDataHash("Iuri", CONTACT_DATA).call({from: accounts[1]});
+      const nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      const signature = await web3.eth.sign(hash, accounts[1]);
+
+      receipt = await Escrow.methods.createEscrow(ethOfferId, fundAmount, 140, accounts[1], CONTACT_DATA, "U", "Iuri", nonce, signature)
+                                    .send({from: accounts[0]});
+
+      escrowId = receipt.events.Created.returnValues.escrowId;
+    });
+
+    it("Should fund escrow and deduct an SNT fee", async () => {
+      // Still requires 2 transactions, because approveAndCall cannot send ETH
+      // TODO: test if inside the contract we can encode the call, and call approveAndCall
+
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value});
+    });
+  });
+
+  describe("Tokens as Asset", async () => {
+    let escrowIdSNT, escrowIdToken;
+
+    beforeEach(async () => {
+      // Reset allowance
+      await SNT.methods.approve(Escrow.options.address, "0").send({from: accounts[0]});
+      await StandardToken.methods.approve(Escrow.options.address, "0").send({from: accounts[0]});
+
+      let hash = await UserStore.methods.getDataHash("Iuri", CONTACT_DATA).call({from: accounts[1]});
+      let signature = await web3.eth.sign(hash, accounts[1]);
+      let nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.createEscrow(SNTOfferId, fundAmount, 140, accounts[1], CONTACT_DATA, "U", "Iuri", nonce,  signature)
+                                    .send({from: accounts[0]});
+      escrowIdSNT = receipt.events.Created.returnValues.escrowId;
+
+      hash = await UserStore.methods.getDataHash("Iuri", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+
+      receipt = await Escrow.methods.createEscrow(tokenOfferId, fundAmount, 140, accounts[1], CONTACT_DATA, "U", "Iuri", nonce, signature)
+                                    .send({from: accounts[0]});
+      escrowIdToken = receipt.events.Created.returnValues.escrowId;
+    });
+
+    const execute = async (token, escrowId) => {
+      const {approvalPromises, trxToSend} = await tokenApprovalAndBuildTrx(token, escrowId);
+      await sequentialPromiseExec(approvalPromises);
+      await trxToSend.send({from: accounts[0]});
+    };
+
+    it("Allowance == to funds and fee. Token is SNT", async () => {
+      const amount = toBN(feeAmount).add(toBN(fundAmount)).toString(10);
+      await SNT.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+
+      await execute(SNT, escrowIdSNT);
+    });
+
+    it("Allowance > to funds and fee. Token is SNT", async () => {
+      const amount = toBN(feeAmount).add(toBN(fundAmount)).add(toBN(100)).toString(10);
+      await SNT.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+
+      await execute(SNT, escrowIdSNT);
+    });
+
+    it("Allowance < than funds and fee. Token is SNT", async () => {
+      const amount = toBN(feeAmount).add(toBN(fundAmount)).sub(toBN(10)).toString(10);
+      await SNT.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+
+      await execute(SNT, escrowIdSNT);
+    });
+
+    it("Allowance == to required funds. Token is not SNT. SNT Allowance == required Fees", async () => {
+      await StandardToken.methods.approve(Escrow.options.address, fundAmount + feeAmount).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance > to required funds. Token is not SNT. SNT Allowance == required Fees", async () => {
+      const amount = toBN(feeAmount).add(toBN(fundAmount)).add(toBN(100)).toString(10);
+      await StandardToken.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance < to required funds. Token is not SNT. SNT Allowance == required Fees", async () => {
+      const amount = toBN(fundAmount).sub(toBN(10)).toString(10);
+      await StandardToken.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance == to required funds. Token is not SNT. SNT Allowance > required Fees", async () => {
+      await StandardToken.methods.approve(Escrow.options.address, fundAmount + feeAmount).send({from: accounts[0]});
+      await SNT.methods.approve(Escrow.options.address, 1000).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance > to required funds. Token is not SNT. SNT Allowance > required Fees", async () => {
+      const amount = toBN(feeAmount).add(toBN(fundAmount)).add(toBN(100)).toString(10);
+      await StandardToken.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+      await SNT.methods.approve(Escrow.options.address, 1000).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance < to required funds. Token is not SNT. SNT Allowance > required Fees", async () => {
+      const amount = toBN(fundAmount).sub(toBN(10)).toString(10);
+      await StandardToken.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+      await SNT.methods.approve(Escrow.options.address, 1000).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance == to required funds. Token is not SNT. SNT Allowance < required Fees", async () => {
+      await StandardToken.methods.approve(Escrow.options.address, fundAmount + feeAmount).send({from: accounts[0]});
+      await SNT.methods.approve(Escrow.options.address, 1).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance > to required funds. Token is not SNT. SNT Allowance < required Fees", async () => {
+      const amount = toBN(feeAmount).add(toBN(fundAmount)).add(toBN(100)).toString(10);
+      await StandardToken.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+      await SNT.methods.approve(Escrow.options.address, 1).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    it("Allowance < to required funds. Token is not SNT. SNT Allowance < required Fees", async () => {
+      const amount = toBN(fundAmount).sub(toBN(10)).toString(10);
+      await StandardToken.methods.approve(Escrow.options.address, amount).send({from: accounts[0]});
+      await SNT.methods.approve(Escrow.options.address, 1).send({from: accounts[0]});
+
+      await execute(StandardToken, escrowIdToken);
+    });
+
+    const tokenApprovalAndBuildTrx = async (token, escrowId) => {
+      const tokenAllowance = await token.methods.allowance(accounts[0], Escrow.options.address).call();
+
+      const toSend = Escrow.methods.fund(escrowId);
+      // const encodedCall = toSend.encodeABI();
+
+      let approvalPromises = [];
+      let trxToSend;
+
+      const resetApproval = (token, tokenAllowance) => {
+        // Reset approval
+        // due to: https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        if(toBN(tokenAllowance).gt(toBN(0))){
+          approvalPromises.push(token.methods.approve(Escrow.options.address, "0").send({from: accounts[0]}));
+        }
+      };
+
+      // Verifying token allowance for funding
+      if (toBN(tokenAllowance).lt(toBN(fundAmount))) {
+        resetApproval(token, tokenAllowance);
+        approvalPromises.push(token.methods.approve(Escrow.options.address, fundAmount + feeAmount).send({from: accounts[0]}));
+      }
+
+      trxToSend = toSend; // Enough funds. Execute directly.
+
+      return {approvalPromises, trxToSend};
+    };
+  });
+
+});

--- a/dapps/tests/teller-contracts/test/license_spec.js
+++ b/dapps/tests/teller-contracts/test/license_spec.js
@@ -1,0 +1,117 @@
+/*global contract, config, it, assert, before, artifacts*/
+
+const License = artifacts.require('License');
+const SNT = artifacts.require('SNT');
+
+let accounts;
+
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+config({
+  contracts: {
+    deploy: {
+      "MiniMeToken": { "deploy": false },
+      "MiniMeTokenFactory": {
+
+      },
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      }
+
+      /*
+      ,
+      StakingPool: {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: ["$SNT"]
+      }
+      */
+
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+});
+
+contract("License", function () {
+  before(async () => {
+    await SNT.methods.generateTokens(accounts[0], 1000).send();
+    await SNT.methods.generateTokens(accounts[2], 1000).send();
+
+  });
+
+  it("should set price on instantiation", async function () {
+    const price = await License.methods.price().call();
+    assert.strictEqual(parseInt(price, 10), 10);
+  });
+
+
+  it("should not allow to buy license when price is incorrect", async function() {
+    try {
+      await SNT.methods.approve(License.options.address, 5).send();
+      await License.methods.buy().send({from: accounts[0]});
+    } catch(error) {
+      assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Unsuccessful token transfer");
+    }
+  });
+
+  it("should allow to buy license", async function() {
+    let isLicenseOwner = await License.methods.isLicenseOwner(accounts[0]).call();
+    assert.strictEqual(isLicenseOwner, false);
+
+    await SNT.methods.approve(License.options.address, 0).send({from: accounts[0]}); // Needs to set allowance to 0 first
+    await SNT.methods.approve(License.options.address, 10).send({from: accounts[0]});
+    await License.methods.buy().send({from: accounts[0]});
+
+    isLicenseOwner = await License.methods.isLicenseOwner(accounts[0]).call();
+    assert.strictEqual(isLicenseOwner, true);
+    // const stakingBalance = await SNT.methods.balanceOf(StakingPool.options.address).call();
+    // FIXME This test doesn't pass even on master
+    // assert.strictEqual(stakingBalance, "10", "Contract balance is incorrect");
+  });
+
+  it("should buy license with approveAndCall", async () => {
+    let isLicenseOwner = await License.methods.isLicenseOwner(accounts[2]).call();
+    assert.strictEqual(isLicenseOwner, false);
+
+    const encodedCall = License.methods.buy().encodeABI();
+    await SNT.methods.approveAndCall(License.options.address, 10, encodedCall).send({from: accounts[2]});
+
+    isLicenseOwner = await License.methods.isLicenseOwner(accounts[2]).call();
+    assert.strictEqual(isLicenseOwner, true);
+  });
+
+  it("should not allow to buy license when the address already owns one", async function() {
+    try {
+      await SNT.methods.approve(License.options.address, 10).send({from: accounts[0]});
+      await License.methods.buy().send({from: accounts[0]});
+    } catch(error) {
+      assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert License already bought");
+    }
+  });
+
+  it("should not allow to set the price if not the owner", async function() {
+    try {
+      await License.methods.setPrice(10).send({from: accounts[1]});
+    } catch (error) {
+      assert.ok(error.message.indexOf('revert') > -1);
+    }
+  });
+
+  it("should allow to set the price if owner", async function() {
+    await License.methods.setPrice(10).send({from: accounts[0]});
+    const price = await License.methods.price().call();
+    assert.strictEqual(parseInt(price, 10), 10);
+  });
+});

--- a/dapps/tests/teller-contracts/test/metadata_store_spec.js
+++ b/dapps/tests/teller-contracts/test/metadata_store_spec.js
@@ -1,0 +1,167 @@
+/*global contract, config, it, assert, before, web3, artifacts*/
+/* eslint require-atomic-updates:0, no-await-in-loop:0*/
+
+const ArbitrationLicense = artifacts.require('ArbitrationLicense');
+
+const SNT = artifacts.require('SNT');
+const UserStore = artifacts.require('UserStore');
+const OfferStore = artifacts.require('OfferStore');
+
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+let accounts;
+
+config({
+  contracts: {
+    deploy: {
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        deploy: false
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+      ArbitrationLicense: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+
+      /*
+      StakingPool: {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: ["$SNT"]
+      },
+      */
+
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      Medianizer: {
+
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"],
+        onDeploy: ["UserStore.methods.setAllowedContract('$OfferStore', true).send()"]
+      }
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+});
+
+let hash, signature;
+
+contract("MetadataStore", function () {
+  before(async () => {
+    await SNT.methods.generateTokens(accounts[0], 1000).send();
+    await SNT.methods.generateTokens(accounts[9], 1000).send();
+
+    const encodedCall = ArbitrationLicense.methods.buy().encodeABI();
+
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall).send({from: accounts[9]});
+
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: accounts[9]});
+
+    hash = await UserStore.methods.getDataHash("Iuri", CONTACT_DATA).call();
+    signature = await web3.eth.sign(hash, accounts[0]);
+  });
+
+  it("should allow to add new user and offer", async function () {
+    const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    await OfferStore.methods.addOffer(SNT.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, accounts[9]).send({value: amountToStake});
+
+    const offersSize = await OfferStore.methods.offersSize().call();
+    assert.strictEqual(offersSize, '1');
+
+    const userInfo = await UserStore.methods.users(accounts[0]).call();
+    assert.strictEqual(userInfo.username, "Iuri");
+  });
+
+  it("should allow to add new offer only when already a user", async function () {
+    const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    await OfferStore.methods.addOffer(SNT.address, CONTACT_DATA, "London", "EUR", "Iuri", [0], 0, 0, 1, accounts[9]).send({value: amountToStake});
+    const offersSize = await OfferStore.methods.offersSize().call();
+    assert.strictEqual(offersSize, '2');
+
+    const offerIds = await OfferStore.methods.getOfferIds(accounts[0]).call();
+    assert.strictEqual(offerIds.length, 2);
+  });
+
+  it("should allow to add new offer when margin is more than 100", async function () {
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      await OfferStore.methods.addOffer(SNT.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 101, accounts[9]).send({value: amountToStake});
+
+      const offerIds = await OfferStore.methods.getOfferIds(accounts[0]).call();
+      assert.strictEqual(offerIds.length, 3);
+  });
+
+  it("should allow to update a user", async function () {
+    await UserStore.methods.addOrUpdateUser(CONTACT_DATA, "Montreal", "Anthony").send();
+    const user = await UserStore.methods.users(accounts[0]).call();
+    assert.strictEqual(user.location, 'Montreal');
+    assert.strictEqual(user.username, 'Anthony');
+  });
+
+  it("should allow to update a user using a signature", async function () {
+    hash = await UserStore.methods.getDataHash("Anthony", CONTACT_DATA).call();
+    signature = await web3.eth.sign(hash, accounts[0]);
+    let nonce = await UserStore.methods.user_nonce(accounts[0]).call();
+
+    await UserStore.methods.addOrUpdateUser(signature, CONTACT_DATA, "Quebec", "Anthony", nonce).send();
+    const user = await UserStore.methods.users(accounts[0]).call();
+    assert.strictEqual(user.location, 'Quebec');
+  });
+
+  it("should allow to delete an offer", async function () {
+    const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+    const receipt = await OfferStore.methods.addOffer(SNT.address, CONTACT_DATA, "London", "EUR", "Iuri", [0], 0, 0, 1, accounts[9]).send({value: amountToStake});
+    const offerAdded = receipt.events.OfferAdded;
+    const offerId = offerAdded.returnValues.offerId;
+
+    const receipt2 = await OfferStore.methods.removeOffer(offerId).send();
+    const offerRemoved = receipt2.events.OfferRemoved;
+    assert(!!offerRemoved, "OfferRemoved() not triggered");
+    assert.strictEqual(offerRemoved.returnValues.owner, accounts[0], "Invalid seller");
+    assert.strictEqual(offerRemoved.returnValues.offerId, offerId, "Invalid offer");
+  });
+
+  it("should not allow adding more than 10 offers", async function () {
+
+    let offerCount = await OfferStore.methods.offerCnt(accounts[0]).call();
+    let offerId;
+    for(let i = 0; i < 10 - offerCount; i++){
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      const receipt = await OfferStore.methods.addOffer(SNT.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, accounts[9]).send({value: amountToStake});
+      const offerAdded = receipt.events.OfferAdded;
+      offerId = offerAdded.returnValues.offerId;
+    }
+
+    try {
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      await OfferStore.methods.addOffer(SNT.address, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, accounts[9]).send({value: amountToStake});
+      assert.fail('should have reverted before');
+    } catch (error) {
+      assert.strictEqual(error.message, "Returned error: VM Exception while processing transaction: revert Exceeds the max number of offers");
+    }
+
+    await OfferStore.methods.removeOffer(offerId).send();
+
+    offerCount = await OfferStore.methods.offerCnt(accounts[0]).call();
+    assert.strictEqual(offerCount, '9');
+  });
+});

--- a/dapps/tests/teller-contracts/test/offer_stake_spec.js
+++ b/dapps/tests/teller-contracts/test/offer_stake_spec.js
@@ -1,0 +1,281 @@
+/*global contract, config, it, assert, web3, before, describe, artifacts*/
+/* eslint require-atomic-updates:0, no-await-in-loop:0*/
+const TestUtils = require("../utils/testUtils");
+
+const ArbitrationLicense = artifacts.require('ArbitrationLicense');
+const OfferStore = artifacts.require('OfferStore');
+const UserStore = artifacts.require('UserStore');
+const Escrow = artifacts.require('Escrow');
+const SNT = artifacts.require('SNT');
+
+const ARBITRATION_SOLVED_SELLER = 2;
+
+let accounts;
+let arbitrator, blacklistedAccount;
+
+const feePercent = 1;
+const BURN_ADDRESS = "0x0000000000000000000000000000000000000002";
+
+const CONTACT_DATA = "Status:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+config({
+  blockchain: {
+    accounts: [
+      {
+        mnemonic: "foster gesture flock merge beach plate dish view friend leave drink valley shield list enemy",
+        balance: "5 ether",
+        numAddresses: "10"
+      }
+    ]
+  },
+  contracts: {
+    deploy: {
+      "MiniMeToken": {"deploy": false},
+      "MiniMeTokenFactory": {},
+      "Medianizer": {},
+      "SNT": {
+        "instanceOf": "MiniMeToken",
+        "args": [
+          "$MiniMeTokenFactory",
+          "0x0000000000000000000000000000000000000000",
+          0,
+          "TestMiniMeToken",
+          18,
+          "STT",
+          true
+        ]
+      },
+      License: {
+        deploy: false
+      },
+      ArbitrationLicense: {
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+      SellerLicense: {
+        instanceOf: "License",
+        args: ["$SNT", 10, BURN_ADDRESS]
+      },
+
+      /*
+      StakingPool: {
+        file: 'staking-pool/contracts/StakingPool.sol',
+        args: ["$SNT"]
+      },
+      */
+
+      UserStore: {
+        args: ["$SellerLicense", "$ArbitrationLicense"]
+      },
+      OfferStore: {
+        args: ["$UserStore", "$SellerLicense", "$ArbitrationLicense", BURN_ADDRESS, "$Medianizer"],
+        onDeploy: ["UserStore.methods.setAllowedContract('$OfferStore', true).send()"]
+      },
+      Escrow: {
+        args: ["$accounts[0]", "0x0000000000000000000000000000000000000000", "$ArbitrationLicense", "$OfferStore", "$UserStore", BURN_ADDRESS, feePercent * 1000],
+        onDeploy: [
+          "OfferStore.methods.setAllowedContract('$Escrow', true).send()",
+          "UserStore.methods.setAllowedContract('$Escrow', true).send()"
+        ]
+      },
+      StandardToken: {}
+    }
+  }
+}, (_err, web3_accounts) => {
+  accounts = web3_accounts;
+  arbitrator = accounts[8];
+  blacklistedAccount = accounts[5];
+});
+
+contract("Escrow", function() {
+
+  const tradeAmount = 100;
+  const feeAmount = Math.round(tradeAmount * (feePercent / 100));
+
+  let receipt, escrowId, ethOfferId, hash, signature, nonce;
+  let created;
+  let offerIds = [];
+
+  this.timeout(0);
+
+  before(async () => {
+    await SNT.methods.generateTokens(accounts[0], 1000).send();
+    await SNT.methods.generateTokens(blacklistedAccount, 1000).send();
+
+    // Register arbitrators
+    await SNT.methods.generateTokens(arbitrator, 1000).send();
+
+    const encodedCall2 = ArbitrationLicense.methods.buy().encodeABI();
+    await SNT.methods.approveAndCall(ArbitrationLicense.options.address, 10, encodedCall2).send({from: arbitrator});
+    await ArbitrationLicense.methods.changeAcceptAny(true).send({from: arbitrator});
+    await ArbitrationLicense.methods.blacklistSeller(blacklistedAccount).send({from: arbitrator});
+  });
+
+  describe("Offer Stake", async() => {
+
+    it("base price should be ~1usd", async() => {
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      // Medianizer for this example has a value of "161567500000000000000", 161.5675 usd per eth
+      const oneUsd = (1 / 161.5675).toFixed(6);
+      const amountToStakeUsd = parseFloat(web3.utils.fromWei(amountToStake, "ether")).toFixed(6);
+      assert.strictEqual(oneUsd, amountToStakeUsd);
+    });
+
+    it("price for each offers should increase exponentially", async() => {
+      let amountToStake;
+
+      // 1st to 4th offer
+      for(let i = 0; i < 4; i++){
+        amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+        assert.strictEqual(amountToStake, "6189000000000000");
+        receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+        offerIds.push(receipt.events.OfferAdded.returnValues.offerId);
+      }
+
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "9101470588235294");
+
+      receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      offerIds.push(receipt.events.OfferAdded.returnValues.offerId);
+
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "13106117647058823");
+
+      receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      offerIds.push(receipt.events.OfferAdded.returnValues.offerId);
+
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "17838882352941176");
+
+      receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      offerIds.push(receipt.events.OfferAdded.returnValues.offerId);
+    });
+
+    it("price should decrease for each offer exponentially", async() => {
+      let currOffer, amountToStake;
+
+      currOffer = offerIds.pop();
+      await OfferStore.methods.removeOffer(currOffer).send();
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "17838882352941176");
+
+      currOffer = offerIds.pop();
+      await OfferStore.methods.removeOffer(currOffer).send();
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "13106117647058823");
+
+      currOffer = offerIds.pop();
+      await OfferStore.methods.removeOffer(currOffer).send();
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "9101470588235294");
+
+      for(let i = 0; i < 3; i++){
+        currOffer = offerIds.pop();
+        await OfferStore.methods.removeOffer(currOffer).send();
+        amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+        assert.strictEqual(amountToStake, "6189000000000000");
+      }
+    });
+
+    it("deleting an offer should refund the stake", async() => {
+      let contractBalance, userBalance1, userBalance2;
+
+      ethOfferId = offerIds.pop();
+
+      userBalance1 = web3.utils.toBN(await web3.eth.getBalance(accounts[0]));
+      contractBalance = await web3.eth.getBalance(OfferStore.options.address);
+      assert.strictEqual(contractBalance, "6189000000000000");
+
+      receipt = await OfferStore.methods.removeOffer(ethOfferId).send();
+      contractBalance = await web3.eth.getBalance(OfferStore.options.address);
+      assert.strictEqual(contractBalance, web3.utils.toWei("0", "ether"));
+
+      userBalance2 = web3.utils.toBN(await web3.eth.getBalance(accounts[0]));
+
+      assert(userBalance1.lt(userBalance2), "User balance did not increase after refund");
+    });
+
+    it("price for each offers should keep increasing exponentially", async() => {
+      let amountToStake;
+
+      // 1st to 4th offer
+      for(let i = 0; i < 4; i++){
+        amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+        assert.strictEqual(amountToStake, "6189000000000000");
+        receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      }
+
+      amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "9101470588235294");
+    });
+
+    it("releasing an escrow should refund the stake and decrease next offer price", async() => {
+      let userBalance1, userBalance2;
+
+      // Create Offer
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "9101470588235294");
+
+      receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
+
+      userBalance1 = web3.utils.toBN(await web3.eth.getBalance(accounts[0]));
+
+      // Create Escrow
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U").send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+
+      // Fund Escrow
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      // Release Escrow
+      receipt = await Escrow.methods.release(escrowId).send({from: accounts[0]});
+
+      userBalance2 = web3.utils.toBN(await web3.eth.getBalance(accounts[0]));
+      assert(userBalance1.lt(userBalance2), "User balance did not increase after refund");
+
+      const stakeDetails = await OfferStore.methods.stakes(ethOfferId).call();
+      assert.strictEqual(stakeDetails.amount, "0");
+    });
+
+    it("price for next offer should not increase", async() => {
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      assert.strictEqual(amountToStake, "9101470588235294");
+    });
+
+    it("winning a dispute should not release the stake (only succesful trades do)", async() => {
+      let initialContractBalance, finalContractBalance;
+
+      // Create Offer
+      const amountToStake = await OfferStore.methods.getAmountToStake(accounts[0]).call();
+      receipt = await OfferStore.methods.addOffer(TestUtils.zeroAddress, CONTACT_DATA, "London", "USD", "Iuri", [0], 0, 0, 1, arbitrator).send({from: accounts[0], value: amountToStake});
+      ethOfferId = receipt.events.OfferAdded.returnValues.offerId;
+
+      initialContractBalance = await web3.eth.getBalance(OfferStore.options.address);
+
+      // Create Escrow
+      hash = await UserStore.methods.getDataHash("U", CONTACT_DATA).call({from: accounts[1]});
+      signature = await web3.eth.sign(hash, accounts[1]);
+      nonce = await UserStore.methods.user_nonce(accounts[1]).call();
+      receipt = await Escrow.methods.createEscrow(ethOfferId, tradeAmount, 140, accounts[1], CONTACT_DATA, "L", "U", nonce, signature).send({from: accounts[1]});
+      created = receipt.events.Created;
+      escrowId = created.returnValues.escrowId;
+
+      // Fund Escrow
+      receipt = await Escrow.methods.fund(escrowId).send({from: accounts[0], value: tradeAmount + feeAmount});
+
+      // Pay Escrow
+      await Escrow.methods.pay(escrowId).send({from: accounts[1]});
+
+      // Open dispute
+      await Escrow.methods.openCase(escrowId, '1').send({from: accounts[1]});
+
+      // Seller wins dispute
+      receipt = await Escrow.methods.setArbitrationResult(escrowId, ARBITRATION_SOLVED_SELLER).send({from: arbitrator});
+
+      finalContractBalance = await web3.eth.getBalance(OfferStore.options.address);
+      assert.strictEqual(finalContractBalance, initialContractBalance);
+    });
+  });
+
+});

--- a/dapps/tests/teller-contracts/utils/testUtils.js
+++ b/dapps/tests/teller-contracts/utils/testUtils.js
@@ -1,0 +1,142 @@
+/*global assert, web3*/
+
+// This has been tested with the real Ethereum network and Testrpc.
+// Copied and edited from: https://gist.github.com/xavierlepretre/d5583222fde52ddfbc58b7cfa0d2d0a9
+exports.assertReverts = (contractMethodCall, maxGasAvailable) => {
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(contractMethodCall());
+    } catch (error) {
+      reject(error);
+    }
+  })
+    .then(tx => {
+      assert.equal(tx.receipt.gasUsed, maxGasAvailable, "tx successful, the max gas available was not consumed");
+    })
+    .catch(error => {
+      if ((String(error)).indexOf("invalid opcode") < 0 && (String(error)).indexOf("out of gas") < 0) {
+        // Checks if the error is from TestRpc. If it is then ignore it.
+        // Otherwise relay/throw the error produced by the above assertion.
+        // Note that no error is thrown when using a real Ethereum network AND the assertion above is true.
+        throw error;
+      }
+    });
+};
+
+exports.listenForEvent = event => new Promise((resolve, reject) => {
+  event({}, (error, response) => {
+    if (!error) {
+      resolve(response.args);
+    } else {
+      reject(error);
+    }
+    event.stopWatching();
+  });
+});
+
+exports.eventValues = (receipt, eventName) => {
+  if (receipt.events[eventName]) return receipt.events[eventName].returnValues;
+};
+
+exports.addressToBytes32 = (address) => {
+  const stringed = "0000000000000000000000000000000000000000000000000000000000000000" + address.slice(2);
+  return "0x" + stringed.substring(stringed.length - 64, stringed.length);
+};
+
+// OpenZeppelin's expectThrow helper -
+// Source: https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/test/helpers/expectThrow.js
+exports.expectThrow = async promise => {
+  try {
+    await promise;
+  } catch (error) {
+    // TODO: Check jump destination to destinguish between a throw
+    //       and an actual invalid jump.
+    const invalidOpcode = error.message.search('invalid opcode') >= 0;
+    // TODO: When we contract A calls contract B, and B throws, instead
+    //       of an 'invalid jump', we get an 'out of gas' error. How do
+    //       we distinguish this from an actual out of gas event? (The
+    //       testrpc log actually show an 'invalid jump' event.)
+    const outOfGas = error.message.search('out of gas') >= 0;
+    const revert = error.message.search('revert') >= 0;
+    assert(
+      invalidOpcode || outOfGas || revert,
+      'Expected throw, got \'' + error + '\' instead',
+    );
+    return;
+  }
+  assert.fail('Expected throw not received');
+};
+
+
+exports.assertJump = (error) => {
+  assert(error.message.search('VM Exception while processing transaction') > -1, 'Revert should happen');
+};
+
+
+function callbackToResolve(resolve, reject) {
+  return function(error, value) {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(value);
+    }
+  };
+}
+
+exports.promisify = (func) =>
+  (...args) => {
+    return new Promise((resolve, reject) => {
+      const callback = (err, data) => err ? reject(err) : resolve(data);
+      func.apply(this, [...args, callback]);
+    });
+  };
+
+exports.zeroAddress = '0x0000000000000000000000000000000000000000';
+exports.zeroBytes32 = "0x0000000000000000000000000000000000000000000000000000000000000000";
+exports.timeUnits = {
+  seconds: 1,
+  minutes: 60,
+  hours: 60 * 60,
+  days: 24 * 60 * 60,
+  weeks: 7 * 24 * 60 * 60,
+  years: 365 * 24 * 60 * 60
+};
+
+exports.ensureException = function(error) {
+  assert(isException(error), error.toString());
+};
+
+function isException(error) {
+  let strError = error.toString();
+  return strError.includes('invalid opcode') || strError.includes('invalid JUMP') || strError.includes('revert');
+}
+
+const evmMethod = (method, params = []) => {
+  return new Promise(function(resolve, reject) {
+    const sendMethod = (web3.currentProvider.sendAsync) ? web3.currentProvider.sendAsync.bind(web3.currentProvider) : web3.currentProvider.send.bind(web3.currentProvider);
+    sendMethod(
+      {
+        jsonrpc: '2.0',
+        method,
+        params,
+        id: new Date().getSeconds()
+      },
+      (error, res) => {
+        if (error) {
+          return reject(error);
+        }
+        resolve(res.result);
+      }
+    );
+  });
+};
+
+exports.evmSnapshot = async () => {
+  const result = await evmMethod("evm_snapshot");
+  return web3.utils.hexToNumber(result);
+};
+
+exports.evmRevert = (id) => {
+  const params = [id];
+  return evmMethod("evm_revert", params);
+};

--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -203,8 +203,8 @@ class MochaTestRunner {
 
             this.fs.readFile(file, (err, data) => {
               if (err) {
-                self.logger.error(__('Error reading file %s', file));
-                self.logger.error(err);
+                this.logger.error(__('Error reading file %s', file));
+                this.logger.error(err);
                 seriesCb(null, 1);
               }
               if (data.toString().search(/contract\(|describe\(/) === -1) {

--- a/packages/plugins/mocha-tests/src/lib/reporter.js
+++ b/packages/plugins/mocha-tests/src/lib/reporter.js
@@ -26,7 +26,7 @@ class Reporter {
       })
       .on(EVENT_TEST_FAIL, (test, err) => {
         const duration = (Date.now() - startTime) / 1000.0;
-        this.reporter.report(test.fullTitle(), duration, false, err.message);
+        this.reporter.report(test.fullTitle(), duration, false, err.message, err.stack);
       });
   }
 }

--- a/packages/stack/test-runner/src/lib/reporter.js
+++ b/packages/stack/test-runner/src/lib/reporter.js
@@ -60,7 +60,7 @@ class Reporter {
     }
   }
 
-  report(test, time, passed, message) {
+  report(test, time, passed, message, stack) {
     let timeFormat = 'green';
     if (time > 0.7) {
       timeFormat = 'yellow';
@@ -76,6 +76,7 @@ class Reporter {
     } else {
       this.fails++;
       this.stdout.write(chalk`{bgRed.white.bold ${' FAIL '}} {underline ${test}} {bold >} {${timeFormat} ${time}s} {bold >} {bold ${formattedGas} gas} > {red ${message || 'no error message'}}\n`);
+      this.stdout.write(chalk`{red ${stack}}\n`);
     }
 
     this.resetGas();


### PR DESCRIPTION
Adds the Teller contracts and tests as a new test Dapp, so that it runs in CI.

Merges in https://github.com/embarklabs/embark/pull/2265 as it uses `proxyFor` and adds a test for it.