### PR TITLE
Fix Ganache node connection and Event emitter warning

### DIFF
--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from 'embark-core';
 import { normalizeInput } from 'embark-utils';
 import { Logger } from 'embark-logger';
-
 const EMBARK_PROCESS_NAME = 'embark';
 
 export class Engine {
@@ -198,7 +197,7 @@ export class Engine {
     });
   }
 
-  serviceMonitor(options) {
+  serviceMonitor(_options) {
     this.servicesMonitor = new ServicesMonitor({ events: this.events, logger: this.logger, plugins: this.plugins });
 
     if (this.servicesMonitor) {
@@ -216,8 +215,7 @@ export class Engine {
     }
   }
 
-  coreComponents(options) {
-
+  coreComponents(_options) {
     // TODO: should be made into a component
     this.processManager = new ProcessManager({
       events: this.events,

--- a/packages/plugins/ganache/package.json
+++ b/packages/plugins/ganache/package.json
@@ -48,6 +48,7 @@
     "core-js": "3.4.3",
     "embark-core": "^5.2.0-nightly.0",
     "embark-i18n": "^5.1.1",
+    "embark-utils": "^5.2.0-nightly.3",
     "ganache-cli": "6.8.2"
   },
   "devDependencies": {

--- a/packages/plugins/ganache/tsconfig.json
+++ b/packages/plugins/ganache/tsconfig.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../../core/i18n"
+    },
+    {
+      "path": "../../core/utils"
     }
   ]
 }

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -45,13 +45,7 @@ export default class Blockchain {
       if (!provider) {
         // Set default provider function
         clientFunctions.provider = async () => {
-          if (this.blockchainConfig.endpoint.startsWith('ws')) {
-            return new Web3.providers.WebsocketProvider(this.blockchainConfig.endpoint, {
-              headers: { Origin: constants.embarkResourceOrigin }
-            });
-          }
-          const web3 = new Web3(this.blockchainConfig.endpoint);
-          return web3.currentProvider;
+          return this.getProviderFromTemplate(this.blockchainConfig.endpoint);
         };
       }
 
@@ -137,6 +131,10 @@ export default class Blockchain {
       }
     });
 
+    this.events.setCommandHandler('blockchain:node:provider:template', (cb) => {
+      cb(null, this.getProviderFromTemplate(this.blockchainConfig.endpoint));
+    });
+
     this.events.setCommandHandler("blockchain:client:register", (clientName, getProviderFunction) => {
       this.blockchainClients[clientName] = getProviderFunction;
     });
@@ -162,6 +160,16 @@ export default class Blockchain {
     if (this.blockchainConfig.enabled && this.blockchainConfig.client === "parity") {
       warnIfPackageNotDefinedLocally("embark-parity", this.embark.logger.warn.bind(this.embark.logger));
     }
+  }
+
+  getProviderFromTemplate(endpoint) {
+    if (endpoint.startsWith('ws')) {
+      return new Web3.providers.WebsocketProvider(endpoint, {
+        headers: { Origin: constants.embarkResourceOrigin }
+      });
+    }
+    const web3 = new Web3(endpoint);
+    return web3.currentProvider;
   }
 
   addArtifactFile(_params, cb) {


### PR DESCRIPTION
I started working on fixing the warning about Event emitter that appearred in the tests, and found a bug about the `-node` option and the Ganache client.

The problem was that the Ganache plugin never actually checked, like other clients, if a node was already started, so it always used the VM.

However, if you used `--node=ws://loc...`, you want Embark to connect to that URL. So, now, Ganache will check if the endpoint is already running, if it is, it will connect to it using a normal web3 provider, otherwise, it will use the VM provider.

So, after fixing that, I could confirm that the Event Emitter problem happens both with the VM provider and without it, meaning that it was not related to Ganche at all.

I finally found that the problem was in the proxy, where we have 2 sources of events that could reach more than 10 listener. It was the request manager and the WS socket connection.

I upped those both to 100, which should be more than enough, but still not too high that we don,t catch leaks.