### PR TITLE
fix(@embark/proxy): only up event listeners on available providers

### DIFF
--- a/packages/stack/proxy/src/proxy.js
+++ b/packages/stack/proxy/src/proxy.js
@@ -42,8 +42,9 @@ export class Proxy {
   _createWeb3RequestManager(provider) {
     const manager =  new Web3RequestManager.Manager(provider);
     // Up max listener because the default 10 limit is too low for all the events the proxy handles
-    // Warning mostly appeared in tests
-    manager.provider.setMaxListeners(100);
+    // Warning mostly appeared in tests. The warning is also only with the Ganache provider
+    // eslint-disable-next-line no-unused-expressions
+    manager.provider?.setMaxListeners?.(100);
     return manager;
   }
 
@@ -53,6 +54,7 @@ export class Proxy {
       // Using net_version instead of eth_accounts, because eth_accounts can fail if EIP1102 is not approved first
       await reqMgr.send({ method: 'net_version' });
     } catch (e) {
+      this.logger.debug(e);
       throw new Error(__(`Unable to connect to the blockchain endpoint`));
     }
   }


### PR DESCRIPTION
Only the  Ganache provider has the setMaxListener