### PR TITLE
fix(@embark/ganache): fix status when ganache is not the client

### DIFF
--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -17,6 +17,7 @@ class Ganache {
         });
       },
       launchFn: (cb) => {
+        this._registerStatusCheck();
         this._getProvider(); // No need to return anything, we just want to populate currentProvider
         this.embark.logger.info(__('Blockchain node is ready').cyan);
         cb();
@@ -39,8 +40,6 @@ class Ganache {
         });
       }
     });
-
-    this._registerStatusCheck();
   }
 
   _getProvider() {


### PR DESCRIPTION
We registered the status check for Ganache even when Ganache was not
the client