### PR TITLE
fix: revert custom `deploy()` API for `EmbarkJS.Contract`

### DIFF
--- a/dapps/tests/app/test/simple_storage_deploy_spec.js
+++ b/dapps/tests/app/test/simple_storage_deploy_spec.js
@@ -5,7 +5,18 @@ const {Utils} = artifacts.require('EmbarkJS');
 contract("SimpleStorage Deploy", function () {
   let simpleStorageInstance;
   before(async () => {
-    simpleStorageInstance = await SimpleStorage.deploy([150]);
+    return new Promise(async (resolve, reject) => {
+      const gas = await SimpleStorage.deploy({arguments: [150]}).estimateGas();
+
+      Utils.secureSend(web3, SimpleStorage.deploy({arguments: [150]}), {gas, from: web3.eth.defaultAccount}, true, function(err, receipt) {
+        if(err) {
+          return reject(err);
+        }
+        simpleStorageInstance = SimpleStorage;
+        simpleStorageInstance.options.address = receipt.contractAddress;
+        resolve();
+      });
+    });
   });
 
   it("should set constructor value", async function () {

--- a/packages/embarkjs/embarkjs/src/lib/blockchain.js
+++ b/packages/embarkjs/embarkjs/src/lib/blockchain.js
@@ -313,7 +313,7 @@ function Contract(options) {
   });
 
   // Assign helpers too
-  for(const method of ["deploy", "new", "at", "send", "deployed"]) {
+  for(const method of ["new", "at", "send", "deployed"]) {
     // Make sure we don't override original methods here.
     if (originalMethods.includes(method)) {
       console.log(method + " is a reserved word and will not be aliased as a helper");
@@ -328,7 +328,7 @@ function Contract(options) {
   return ContractClass;
 }
 
-Contract.prototype.deploy = function(args, _options, _txOptions) {
+Contract.prototype.new = function(args, _options, _txOptions) {
   const self = this;
   const options = Object.assign({
     arguments: args || [],
@@ -357,8 +357,6 @@ Contract.prototype.deploy = function(args, _options, _txOptions) {
 
   return this._deployPromise;
 };
-
-Contract.prototype.new = Contract.prototype.deploy;
 
 Contract.prototype.at = function(address) {
   return new Contract({abi: this.abi, code: this.code, address: address});


### PR DESCRIPTION
`.deploy()` is an alias to `.new()` and in other tools also no longer used
as API to deploy instances. In addition, we don't want it to shadow the
original web3 `deploy()` API which actually caused a breeaking change.
