### PR TITLE
fix: don't open external links to another tab by default

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -38,3 +38,5 @@ node_sass:
   outputStyle: nested
   precision: 5
   sourceComments: false
+external_link:
+  enable: false


### PR DESCRIPTION
This caused a problem for links that were not from the subdomain,
but still part of embarklabs.io, because it opened a new tab