### PR TITLE
fix(stack/proxy): ensure wsProxy and httpProxy have correct type

### DIFF
--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -135,11 +135,12 @@ export default class ProxyManager {
       isWs: false,
       logger: this.logger,
       plugins: this.plugins
-    })
-      .serve(
-        this.host,
-        this.rpcPort,
-      );
+    });
+
+    this.httpProxy.serve(
+      this.host,
+      this.rpcPort,
+    );
     this.logger.info(`HTTP Proxy for node endpoint ${endpoint} listening on ${buildUrl("http", this.host, this.rpcPort, "rpc")}`);
     if (this.isWs) {
       this.wsProxy = await new Proxy({
@@ -147,22 +148,25 @@ export default class ProxyManager {
         isWs: true,
         logger: this.logger,
         plugins: this.plugins
-      })
-        .serve(
-          this.host,
-          this.wsPort,
-        );
+      });
+
+      this.wsProxy.serve(
+        this.host,
+        this.wsPort,
+      );
       this.logger.info(`WS Proxy for node endpoint ${endpoint} listening on ${buildUrl("ws", this.host, this.wsPort, "ws")}`);
     }
   }
   private stopProxy() {
-    if (this.wsProxy) {
-      this.wsProxy.stop();
-      this.wsProxy = null;
-    }
-    if (this.httpProxy) {
-      this.httpProxy.stop();
-      this.httpProxy = null;
-    }
+    return new Promise(resolve => {
+      if (this.wsProxy) {
+        this.wsProxy.stop(resolve);
+        this.wsProxy = null;
+      }
+      if (this.httpProxy) {
+        this.httpProxy.stop(resolve);
+        this.httpProxy = null;
+      }
+    });
   }
 }


### PR DESCRIPTION
Both, `httpProxy` and `wsProxy` inside `Proxymanager` have been assigned
the value of `new Proxy(...).serve()` which is an instance of `express`.

This was wrong and causes runtime errors when proxies are being stopped as
they don't have a `stop()` API.

### What did you refactor, implement, or fix?

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

#### How did you do it?

<!-- Provide a summary of the improvement/s you are submitting. -->

#### Is there anything that needs special attention (breaking changes, etc)?

<!-- Explain any special considerations. -->

### Questions

<!-- If relevant, write a list of questions that you would like to discuss related to your changes. -->

### Review

<!-- Use @mentions for quick questions, specific feedback, and progress updates. -->

### Cool Spaceship Picture

<!-- Star Trek/Wars, n/BSG, Voltron, Transformers... all welcome, but not all equally cool ;-) ->
