### PR TITLE
feat: add support for `embark.config.js`

### DIFF
--- a/packages/core/console/src/index.ts
+++ b/packages/core/console/src/index.ts
@@ -169,7 +169,7 @@ export default class Console {
       return this.ipc.request("console:executeCmd", cmd, callback);
     }
 
-    if (cmd.indexOf("profile") === 0 && warnIfPackageNotDefinedLocally("embark-profiler", this.embark.logger.warn) !== true) {
+    if (cmd.indexOf("profile") === 0 && warnIfPackageNotDefinedLocally("embark-profiler", this.embark.logger.warn, this.embark.config.embarkConfig) !== true) {
       return callback(null, "please install embark-profiler plugin");
     }
     if (!(cmd.split(" ")[0] === "history" || cmd === __("history"))) {

--- a/packages/core/engine/src/index.ts
+++ b/packages/core/engine/src/index.ts
@@ -121,8 +121,8 @@ export class Engine {
   }
 
   async generateEmbarkJSON() {
-    if (fs.existsSync('embark.json')) {
-      throw new Error(__('embark.json already there. Will not overwrite'));
+    if (fs.existsSync('embark.json') || fs.existsSync('embark.config.js')) {
+      throw new Error(__('embark.json or embark.config.js already exist. Will not overwrite'));
     }
     return fs.writeFile('embark.json', JSON.stringify(constants.defaultEmbarkConfig, null, 2));
   }

--- a/packages/core/utils/src/index.ts
+++ b/packages/core/utils/src/index.ts
@@ -313,7 +313,7 @@ export function isEs6Module(module) {
   return (typeof module === 'function' && isConstructor(module)) || (typeof module === 'object' && typeof module.default === 'function' && module.__esModule);
 }
 
-export function warnIfPackageNotDefinedLocally(packageName, warnFunc) {
+export function warnIfPackageNotDefinedLocally(packageName, warnFunc, embarkConfig) {
   const packageIsResolvable = findUp.sync("node_modules/" + packageName, {cwd: dappPath()});
   if (!packageIsResolvable) {
     return warnFunc("== WARNING: "  + packageName + " could not be resolved; ensure it is defined in your dapp's package.json dependencies and then run npm or yarn install; in future versions of embark this package should be a local dependency and configured as a plugin");
@@ -325,7 +325,6 @@ export function warnIfPackageNotDefinedLocally(packageName, warnFunc) {
     return warnFunc("== WARNING: it seems "  + packageName + " is not defined in your dapp's package.json dependencies; In future versions of embark this package should be a local dependency and configured as a plugin");
   }
 
-  const embarkConfig = fs.readJSONSync(dappPath("embark.json"));
   if (!embarkConfig.plugins[packageName]) {
     return warnFunc(
       __("== WARNING: it seems %s is not defined in your Dapp's embark.json plugins;\nIn future versions of Embark, this package should be a local dependency and configured as a plugin", packageName)

--- a/packages/plugins/basic-pipeline/src/index.js
+++ b/packages/plugins/basic-pipeline/src/index.js
@@ -117,7 +117,8 @@ class BasicPipeline {
           options: {
             webpackConfigName: self.webpackConfigName,
             pipelineConfig: self.pipelineConfig,
-            fs: self.embark.fs
+            fs: self.embark.fs,
+            embarkConfig: self.embark.config.embarkConfig
           }
         });
         webpackProcess.send({action: constants.pipeline.build, assets: self.assetFiles, importsList});

--- a/packages/plugins/basic-pipeline/src/webpack.config.js
+++ b/packages/plugins/basic-pipeline/src/webpack.config.js
@@ -54,9 +54,9 @@ const embarkAliases = require(path.join(dappPath, '.embark/embark-aliases.json')
 const embarkAssets = require(path.join(dappPath, '.embark/embark-assets.json'));
 let embarkJson;
 try {
-  embarkJson = require(path.join(dappPath, 'embark.json'));
-}catch (e) {
-  throw new Error('embark.json not found. To build your app, please add an embark.json file with a `buildDir` field');
+  embarkJson = require(path.join(dappPath, '.embark', 'embark.json'));
+} catch (e) {
+  throw new Error(`embark.json not found in ${path.join(dappPath, '.embark')}/`);
 }
 
 const embarkPipeline = require(path.join(dappPath, '.embark/embark-pipeline.json'));

--- a/packages/plugins/basic-pipeline/src/webpackProcess.js
+++ b/packages/plugins/basic-pipeline/src/webpackProcess.js
@@ -13,6 +13,7 @@ class WebpackProcess extends ProcessWrapper {
     super(options);
     this.webpackConfigName = options.webpackConfigName;
     this.pipelineConfig = options.pipelineConfig;
+    this.embarkConfig = options.embarkConfig;
   }
 
   async build(assets, importsList, callback) {
@@ -25,6 +26,10 @@ class WebpackProcess extends ProcessWrapper {
 
   async webpackRun(assets, importsList, callback) {
     try {
+      await writeFile(
+        dappPath('.embark/embark.json'),
+        JSON.stringify(this.embarkConfig)
+      );
       await writeFile(
         dappPath('.embark/embark-aliases.json'),
         JSON.stringify(importsList)

--- a/packages/plugins/graph/src/index.js
+++ b/packages/plugins/graph/src/index.js
@@ -9,7 +9,7 @@ class GraphGenerator {
     this.events = embark.events;
 
     this.events.setCommandHandler("graph:create", this.generate.bind(this));
-    warnIfPackageNotDefinedLocally("embark-graph", this.embark.logger.warn.bind(this.embark.logger));
+    warnIfPackageNotDefinedLocally("embark-graph", this.embark.logger.warn.bind(this.embark.logger), this.embark.config.embarkConfig);
   }
 
   /*eslint complexity: ["error", 21]*/

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -161,10 +161,10 @@ export default class Blockchain {
     this.blockchainApi.registerRequests("ethereum");
 
     if (this.blockchainConfig.enabled && this.blockchainConfig.client === "geth") {
-      warnIfPackageNotDefinedLocally("embark-geth", this.embark.logger.warn.bind(this.embark.logger));
+      warnIfPackageNotDefinedLocally("embark-geth", this.embark.logger.warn.bind(this.embark.logger), this.embark.config.embarkConfig);
     }
     if (this.blockchainConfig.enabled && this.blockchainConfig.client === "parity") {
-      warnIfPackageNotDefinedLocally("embark-parity", this.embark.logger.warn.bind(this.embark.logger));
+      warnIfPackageNotDefinedLocally("embark-parity", this.embark.logger.warn.bind(this.embark.logger), this.embark.config.embarkConfig);
     }
   }
 

--- a/packages/stack/communication/src/index.js
+++ b/packages/stack/communication/src/index.js
@@ -32,7 +32,7 @@ class Communication {
     });
 
     if (this.communicationConfig.enabled && this.communicationConfig.available_providers.includes("whisper")) {
-      warnIfPackageNotDefinedLocally("embark-whisper-geth", this.embark.logger.warn.bind(this.embark.logger));
+      warnIfPackageNotDefinedLocally("embark-whisper-geth", this.embark.logger.warn.bind(this.embark.logger), this.embark.config.embarkConfig);
     }
   }
 

--- a/packages/stack/storage/src/index.js
+++ b/packages/stack/storage/src/index.js
@@ -44,10 +44,10 @@ class Storage {
     });
 
     if (this.storageConfig.enabled && this.storageConfig.available_providers.includes("ipfs")) {
-      warnIfPackageNotDefinedLocally("embark-ipfs", this.embark.logger.warn.bind(this.embark.logger));
+      warnIfPackageNotDefinedLocally("embark-ipfs", this.embark.logger.warn.bind(this.embark.logger), this.embark.config.embarkConfig);
     }
     if (this.storageConfig.enabled && this.storageConfig.available_providers.includes("swarm")) {
-      warnIfPackageNotDefinedLocally("embark-swarm", this.embark.logger.warn.bind(this.embark.logger));
+      warnIfPackageNotDefinedLocally("embark-swarm", this.embark.logger.warn.bind(this.embark.logger), this.embark.config.embarkConfig);
     }
   }
 

--- a/site/source/docs/configuration.md
+++ b/site/source/docs/configuration.md
@@ -35,7 +35,22 @@ Every application [created with Embark](create_project.html) comes with an `emba
 }
 ```
 
-Let's look at the different options and learn what they do and mean.
+Alternatively, it's possible to use a `embark.config.js` file, which exports either a configuration object or a function that calculates the object. This is particularly useful when the configuration needs to be built based on asynchronous operations. To make use of `embark.config.js`, simply create the file in your DApp and make sure it exports an (async) function which resolves with a config object like this:
+
+```js
+// embark.config.js
+
+module.exports = async function () {
+  const secrets = await getSecrets();
+  return {
+    // Embark configuration goes here
+  };
+};
+```
+
+Embark will import and run the exported function. If `module.exports` is a `Promise` or a function that returns a `Promise` (as above), Embark will automatically resolve the promised config object.
+
+Let's look at the different configuration options and learn what they do and mean.
 
 ### contracts
 

--- a/site/source/docs/structure.md
+++ b/site/source/docs/structure.md
@@ -74,6 +74,10 @@ This file is used to keep track of the deployed contracts in each chain. This is
 
 In order to provide as much flexibility for our users as possible, Embark comes with an `embark.json` file that lets us configure our own directory structure. This file is also used to specify Embark plugins and other configurations. More information on how to use this configuration file, can be found in [configuring embark.json](configuration.html).
 
+### embark.config.js
+
+If we need more control over how our `embark.json` configuration object should be composed, `embark.config.js` can be used as a module that exports either a configuration object or a function that returns a configuration object. That way, we can perform any calculations needed. For more information, checkout the [embark.config.js section](configuration.html#embark.config.js).
+
 ## Smart Contracts only template structure
 
 When creating a project using the `--contracts-only` option, the resulting structure is a little bit simpler. Let's take quick look:


### PR DESCRIPTION
See #2277. This PR is derived from that one, the main difference being the approach taken in `packages/embark/src/bin/embark.js`. It also fixes a bug arising from #2260 that results in `EMBARK_NO_SHIM` scenarios failing because no argument is passed to `EmbarkBin.prototype.exec`.

---

This commit introduces support for using `embark.config.js` to calculate the embark configuration object that is otherwise provided via `embark.json`.

If an `embark.config.js` file is present, it will be used over the `embark.json` file.  The `embark.config.js` module needs to export either an object or a function that can be asynchronous and has to return or resolve with an embark configuration object:

```js
// embark.config.js

module.exports = async function () {
  let config = ...; // do lazy calculation of `embarkConfig`;
  return config;
}
```