### PR TITLE
fix(@embark/ganache): make embark blockchain exit when using Ganache

### DIFF
--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -20,7 +20,7 @@ class Ganache {
         this._registerStatusCheck();
         this._getProvider(); // No need to return anything, we just want to populate currentProvider
         this.embark.logger.info(__('Blockchain node is ready').cyan);
-        cb();
+        cb(null, true);
       },
       stopFn: (cb) => {
         this.currentProvider = null;

--- a/packages/stack/blockchain/src/index.js
+++ b/packages/stack/blockchain/src/index.js
@@ -78,9 +78,9 @@ export default class Blockchain {
           return cb(null, true);
         }
         // start node
-        client.launchFn.call(client, () => {
+        client.launchFn.call(client, (_err, isVM) => {
           started();
-          cb();
+          cb(null, isVM);
         });
       });
     });

--- a/packages/stack/proxy/src/index.ts
+++ b/packages/stack/proxy/src/index.ts
@@ -130,7 +130,6 @@ export default class ProxyManager {
 
     // HTTP
     this.httpProxy = await new Proxy({
-      endpoint,
       events: this.events,
       isWs: false,
       logger: this.logger,


### PR DESCRIPTION
Since we changed the Ganache plugin to work exactly like a real Node plugin, it also meant that when doing `embark blockchain`, it acted as if a node was started and ready to be used, when in fact, it was just creating a useless process, since the provider is not shared between the Embark instances.

Instead, I return `true` on the `start` action, so that the blockchain command sees that as if the Node was already started. If we ever have other VM clients, we just have to do the same,
