### PR TITLE
feat(@embark/core): Support minimum truffle projects

### DIFF
--- a/packages/core/core/src/config.ts
+++ b/packages/core/core/src/config.ts
@@ -562,7 +562,7 @@ export class Config {
   loadCommunicationConfigFile() {
     const configObject = {
       default: {
-        enabled: true,
+        enabled: false,
         provider: "whisper",
         available_providers: ["whisper"],
         client: "geth",


### PR DESCRIPTION
When taking a bare-minimum truffle project, created from the [`metacoin` truffle box](https://github.com/truffle-box/metacoin-box), there were only two steps that needed to happen as a prerequisite:
1. First, run `embark init`, creating a default `embark.json`
2. Second, run `npm init`, creating a default `package.json`.

Trying to run `embark run` before those prequisites would error with appropriate directions in the console, guiding the user to run those steps explicitly.

After running these two steps, Embark would hang waiting for the namesystem plugin to come up.

Changing the default namesystem config to disabled allows Embark to start up successfully without hanging.

The rationale behind this decision is that if `embark.json` doesn’t exist, then we cannot expect that the namesystem plugin will be installed in the project either, and thefore its default value should be disabled.