### PR TITLE
fix(@embark/cmd_controller): don't try to load pipeline module group …

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -303,7 +303,6 @@ class EmbarkController {
 
         if (!options.onlyCompile) {
           engine.registerModulePackage('embark-ganache');
-          engine.registerModuleGroup("pipeline");
           engine.registerModuleGroup("namesystem");
           engine.registerModulePackage('embark-deploy-tracker', { plugins: engine.plugins });
         }


### PR DESCRIPTION
…in build cmd

We've made the `basic-pipeline` optional in https://github.com/embarklabs/embark/commit/948956ab1f7fde154e4a4a36c58cfa677ecff9c6 but are still
trying to load the pipeline module group in inside the `build` cmd.
This breaks at runtime as no such module group exists anymore.
