### PR TITLE
fix(@embark/blockchain): fix blockchain plugins' use of async whilst

### DIFF
--- a/packages/plugins/ganache/src/index.js
+++ b/packages/plugins/ganache/src/index.js
@@ -53,8 +53,6 @@ class Ganache {
     // => https://github.com/trufflesuite/ganache-cli/issues/558
     this.embark.fs.ensureDirSync(blockchainConfig.datadir);
 
-    const hasAccounts = blockchainConfig.accounts && blockchainConfig.accounts.length;
-
     const isTest = this.embark.currentContext.includes('test');
 
     this.currentProvider = ganache.provider({
@@ -65,7 +63,7 @@ class Ganache {
       network_id: blockchainConfig.networkId || 1337,
       db_path: isTest ? '' : blockchainConfig.datadir,
       default_balance_ether: '99999',
-      mnemonic: hasAccounts || isTest ? '' : constants.blockchain.defaultMnemonic
+      mnemonic: isTest ? '' : constants.blockchain.defaultMnemonic
     });
     return this.currentProvider;
   }

--- a/packages/plugins/geth/src/blockchain.js
+++ b/packages/plugins/geth/src/blockchain.js
@@ -337,8 +337,8 @@ class Blockchain {
           if (!newAccountCommand) return next();
           var accountNumber = 0;
           async.whilst(
-            function () {
-              return accountNumber < accountsToCreate;
+            function (cb) {
+              cb(null, accountNumber < accountsToCreate);
             },
             function (callback) {
               accountNumber++;

--- a/packages/plugins/parity/src/blockchain.js
+++ b/packages/plugins/parity/src/blockchain.js
@@ -346,8 +346,8 @@ class Blockchain {
         function newAccounts(accountsToCreate, next) {
           var accountNumber = 0;
           async.whilst(
-            function () {
-              return accountNumber < accountsToCreate;
+            function (cb) {
+              cb(null, accountNumber < accountsToCreate);
             },
             function (callback) {
               accountNumber++;


### PR DESCRIPTION
We updated async's version and there was a change in async's `whilst` where the condition needs to be a callback and not just a return.

Edit: also added a commit that fixes a Ganache bug where the node accounts changed in between runs when using custom accounts