### PR TITLE
build: implement a script to fix intra-monorepo dep range specifiers in rebased branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "cwtree": "node scripts/check-working-tree",
     "cylock": "node scripts/check-yarn-lock",
     "deploy:site": "node site/deploy-site",
+    "fix-versions": "node scripts/fix-versions",
     "globalize": "node scripts/globalize",
     "lint": "npm-run-all lint:*",
     "lint:packages": "node scripts/monorun --parallel lint",

--- a/scripts/fix-versions.js
+++ b/scripts/fix-versions.js
@@ -1,0 +1,63 @@
+const { execSync } = require('child_process');
+const { writeFileSync } = require('fs');
+const { join } = require('path');
+const semver = require('semver');
+
+const allPackages = JSON.parse(execSync(
+  'npx lerna ls --all --json',
+  {cwd: join(__dirname, '..'), stdio: ['pipe', 'pipe', 'ignore']}
+).toString().trim());
+
+const allPackagesDict = {};
+
+allPackages.forEach(pkg => {
+  pkg.json = require(join(pkg.location, 'package.json'));
+  allPackagesDict[pkg.name] = pkg;
+});
+
+allPackages.forEach(pkg => {
+  function updateMismatched(depKind, [depName, depRange]) {
+    const dep = allPackagesDict[depName];
+    if (dep) {
+      const depVersion = dep.version;
+      if (!semver.satisfies(depVersion, depRange)) {
+        pkg.json[depKind][depName] = `^${depVersion}`;
+        pkg.updated = true;
+        console.warn([
+          `range specifier for ${depName} was set to ^${depVersion} in`,
+          `${join(pkg.location, 'package.json')} based on "version" in`,
+          `${join(dep.location, 'package.json')}`
+        ].join(' '));
+      }
+    }
+  }
+
+  if (pkg.json.dependencies) {
+    Object.entries(pkg.json.dependencies).forEach(
+      updateMismatched.bind({}, 'dependencies')
+    );
+  }
+  if (pkg.json.devDependencies) {
+    Object.entries(pkg.json.devDependencies).forEach(
+      updateMismatched.bind({}, 'devDependencies')
+    );
+  }
+});
+
+let updated;
+allPackages.forEach(pkg => {
+  if (pkg.updated) {
+    updated = true;
+    writeFileSync(
+      join(pkg.location, 'package.json'),
+      JSON.stringify(pkg.json, null, 2)
+    );
+  }
+});
+
+if (updated) {
+  execSync(
+    'yarn reboot:full && yarn cylock',
+    {cwd: join(__dirname, '..'), stdio: 'inherit'}
+  );
+}


### PR DESCRIPTION
Range specifiers for intra-monorepo dependencies can, because of nightly or stable releases, get out of sync between PR branches and `master`. In many cases, what then happens is that yarn can't satisfy the dep range with the version in the monorepo, so it installs from the registry and updates `yarn.lock` accordingly. We have a `check-yarn-lock.js` script (`yarn cylock`) that detects the situation and prevents CI from passing. However, to date the problem has to be fixed manually.

Implement a script that fixes the problem by scanning all the `package.json` files and updating mismatched ranges.

It's best to run the script *after* rebasing against `master`.