### PR TITLE
refactor: modify check-yarn-lock.js to use a blacklist instead of a whitelist

### DIFF
--- a/scripts/check-yarn-lock.js
+++ b/scripts/check-yarn-lock.js
@@ -1,26 +1,30 @@
-const {readFileSync} = require('fs');
-const {join} = require('path');
+const { execSync } = require('child_process');
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const allPackages = JSON.parse(execSync(
+  'npx lerna ls --all --json',
+  {cwd: join(__dirname, '..'), stdio: ['pipe', 'pipe', 'ignore']}
+).toString().trim());
+
+const allPackagesNames = new Set(allPackages.map(pkg => pkg.name));
 
 try {
   const yarnLock = readFileSync(join(__dirname, '..', 'yarn.lock')).toString();
-  const embarkPkgs = yarnLock.match(/embark(js)?(-\S+)?@|@embarklabs\/\S+@/g);
-  const badSpecTest = spec => (
-    !(spec.startsWith('embark-test-contract-') ||
-      spec.startsWith('@embarklabs/ethereumjs-wallet'))
-  );
-  if (embarkPkgs &&
-      embarkPkgs.some(badSpecTest)) {
-    let badSpecs = [...(new Set(embarkPkgs))]
-        .filter(badSpecTest)
-        .map(spec => spec.slice(0, -1));
-    const plur = badSpecs.length > 1;
+  const embarkPkgs = yarnLock
+        .match(/embark(js)?(-\S+)?@|@embarklabs\/\S+@/g)
+        .map(match => match.slice(0, -1));
+  const badPkgTest = pkgName => allPackagesNames.has(pkgName);
+  if (embarkPkgs && embarkPkgs.some(badPkgTest)) {
+    let badPkgNames = [...(new Set(embarkPkgs))].filter(badPkgTest);
+    const plur = badPkgNames.length > 1;
     console.error();
     console.error(
       [
-        `Found specifier${plur ? 's' : ''} for ${badSpecs.join(', ')} in the`,
-        `root yarn.lock file.\n\nThis probably happened because some package's`,
-        `version and/or dev/Deps specifiers need to be adjusted relative to`,
-        `the current versions in the master branch.`
+        `Found specifier${plur ? 's' : ''} for ${badPkgNames.join(', ')} in`,
+        `the root yarn.lock file.\n\nThis probably happened because some`,
+        `package's version and/or dev/Deps specifiers need to be adjusted`,
+        `relative to the current versions in the master branch.`
       ].join(' ')
     );
     console.error();


### PR DESCRIPTION
Refactor `scripts/check-yarn-lock.js` to use a dynamically calculated blacklist (`npx lerna ls --all --json`) instead of a hard-coded whitelist to improve accuracy and reduce future maintenance.

---

I got the idea when working on #2351.