### PR TITLE
fix(plugins/solc): don't read pluginConfig from plugin.config

### DIFF
--- a/packages/plugins/solc/src/lib/Compiler.js
+++ b/packages/plugins/solc/src/lib/Compiler.js
@@ -51,7 +51,7 @@ function compileSolc(embark, contractFiles, contractDirectories, options, callba
   }
 
   const logger = embark.logger;
-  const outputBinary = embark.config.pluginConfig.outputBinary;
+  const outputBinary = embark.pluginConfig.outputBinary;
   const outputDir = embark.config.buildDir + embark.config.contractDirectories[0];
   const solcConfig = embark.config.embarkConfig.options.solc;
 

--- a/packages/utils/testing/src/embark.js
+++ b/packages/utils/testing/src/embark.js
@@ -7,6 +7,7 @@ class Embark {
     this.plugins = plugins;
     this.config = config || {};
     this.config.plugins = plugins;
+    this.pluginConfig = config.pluginConfig || {};
     this.ipc = ipc;
     this.config.ipc = ipc;
     this.assert = new EmbarkAssert(this);


### PR DESCRIPTION
In https://github.com/embarklabs/embark/pull/2330#discussion_r389906144 we've changed the `solc` plugin to read its
`pluginConfig` from `embark.config`. This was done under the assumption that
the `embark.config` is always properly populated with a dedicated `pluginConfig`.
In our testing environment we pass `Embark` objects to plugins, while in reality, we pass `Plugin` instances.
These two are different in nature, so relying on `embark.config` inside the plugin seemed the
most pragmatic way forward without introducing a bigger refactoring in the testing APIs.

Unfortunately it turned out that `embark.config` isn't populated with a `pluginConfig`
which essentially caused it to break apps.

This commit reverts that change done in the mentioned PR and patches the Embark testing
API to behave like a `Plugin` while still being an `Embark` instance.