### PR TITLE
fix(@embark/mocha): reset contracts before each test file

### DIFF
--- a/packages/plugins/mocha-tests/src/lib/index.js
+++ b/packages/plugins/mocha-tests/src/lib/index.js
@@ -114,6 +114,10 @@ class MochaTestRunner {
             });
           },
           (next) => {
+          // Reset contract config to make sure we don't deploy old contracts or worse, call old onDeploys
+            events.request("contracts:reset", next);
+          },
+          (next) => {
           // Remove contracts that are not in the configs
             const realContracts = {};
             const deployKeys = Object.keys(cfg.contracts.deploy);


### PR DESCRIPTION
Caused issues because we kept in memory the old contracts, including
the onDeploys.