### PR TITLE
fix(@embark/storage): Allow upload when storage is disabled

### DIFF
--- a/packages/embark/src/cmd/cmd_controller.js
+++ b/packages/embark/src/cmd/cmd_controller.js
@@ -716,7 +716,7 @@ class EmbarkController {
     async.waterfall([
       function initEngine(callback) {
         engine.init({}, () => {
-          if (engine.config.embarkConfig.config.storage === false || engine.config.storageConfig.enabled === false) {
+          if (engine.config.embarkConfig.config.storage === false) {
             engine.logger.error(__('Storage configuration is disabled in embark.json. Please provide a storage file before uploading'));
             engine.logger.info(__('You can find an example here: %s', 'https://github.com/embarklabs/embark/blob/master/templates/demo/config/storage.js'.underline));
             process.exit(1);


### PR DESCRIPTION
Even when the storage config sets storage to disabled, upload should still be allowed, as uploaded dapps should have the ability to NOT use storage once uploaded.