### PR TITLE
style(@cockpit): remove unused var causing a linter failure in a CI environment or production build

### DIFF
--- a/packages/cockpit/ui/package.json
+++ b/packages/cockpit/ui/package.json
@@ -67,6 +67,7 @@
     "connected-react-router": "4.5.0",
     "date-fns": "2.3.0",
     "embark-api-client": "^5.3.0-nightly.4",
+    "eslint-plugin-flowtype": "3.13.0",
     "ethereumjs-units": "0.2.0",
     "find-up": "4.1.0",
     "font-awesome": "4.7.0",

--- a/packages/cockpit/ui/src/containers/HomeContainer.js
+++ b/packages/cockpit/ui/src/containers/HomeContainer.js
@@ -16,7 +16,6 @@ import {
   stopProcessLogs
 } from "../actions";
 
-import DataWrapper from "../components/DataWrapper";
 import Console from '../components/Console';
 import {EMBARK_PROCESS_NAME, LOG_LIMIT} from '../constants';
 import PageHead from '../components/PageHead';

--- a/packages/embarkjs/snark/package.json
+++ b/packages/embarkjs/snark/package.json
@@ -66,8 +66,6 @@
   "devDependencies": {
     "embark-solo": "^5.1.1-nightly.2",
     "eslint": "6.2.2",
-    "eslint-config-prettier": "6.1.0",
-    "eslint-plugin-prettier": "3.1.0",
     "lodash.clonedeep": "4.5.0",
     "npm-run-all": "4.1.5",
     "rimraf": "3.0.0",

--- a/packages/plugins/quorum/package.json
+++ b/packages/plugins/quorum/package.json
@@ -49,6 +49,7 @@
     "embark-utils": "^5.3.0-nightly.16",
     "ethers": "4.0.40",
     "quorum-js": "0.3.4",
+    "request": "2.88.0",
     "web3": "1.2.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8910,6 +8910,13 @@ eslint-module-utils@^2.0.0, eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-flowtype@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz#e241ebd39c0ce519345a3f074ec1ebde4cf80f2c"
+  integrity sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==
+  dependencies:
+    lodash "^4.17.15"
+
 eslint-plugin-flowtype@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz#82b2bd6f21770e0e5deede0228e456cb35308451"


### PR DESCRIPTION
Also fix some peer dependency related warnings seen during `yarn install`.