### PR TITLE
Remove Teller from the footer

### DIFF
--- a/site/themes/embark/layout/partial/footer.swig
+++ b/site/themes/embark/layout/partial/footer.swig
@@ -68,7 +68,6 @@
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://status.im/" target="_blank">Status</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://keycard.tech/" target="_blank">Keycard</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://dap.ps/" target="_blank">dap.ps</a></li>
-            <li class="o-list-bare__item"><a class="u-link-ghost" href="https://teller.exchange/" target="_blank">Teller</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://assemble.fund/" target="_blank">Assemble</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://subspace.embarklabs.io/" target="_blank">Subspace</a></li>
             <li class="o-list-bare__item"><a class="u-link-ghost" href="https://vac.dev/" target="_blank">Vac</a></li>


### PR DESCRIPTION
Remove Teller as per Jonny's request

Before
<img width="270" alt="Screen Shot 2020-06-26 at 12 03 08 AM" src="https://user-images.githubusercontent.com/41753422/85745573-c3dc3500-b740-11ea-8757-ce41f930caff.png">

After
<img width="280" alt="Screen Shot 2020-06-26 at 12 03 12 AM" src="https://user-images.githubusercontent.com/41753422/85745588-c6d72580-b740-11ea-91d4-d0b4262fa584.png">
