### PR TITLE
fix(@embark/specialconfigs): fix deploy hooks dependency generation

### DIFF
--- a/dapps/tests/app/test/token_spec.js
+++ b/dapps/tests/app/test/token_spec.js
@@ -5,6 +5,7 @@ const MyToken = artifacts.require('MyToken');
 const MyToken2 = artifacts.require('MyToken2');
 const AlreadyDeployedToken = artifacts.require('AlreadyDeployedToken');
 const Test = artifacts.require('Test');
+const TestOnDeploy = artifacts.require('TestOnDeploy');
 const SomeContract = artifacts.require('SomeContract');
 
 config({
@@ -40,6 +41,13 @@ config({
       },
       Test: {
         onDeploy: ["Test.methods.changeAddress('$MyToken').send()", "Test.methods.changeENS('embark.eth').send()"]
+      },
+      TestOnDeploy: {
+        instanceOf: "Test",
+        onDeploy: async ({contracts, _web3, _logger}) => {
+          await contracts.TestOnDeploy.methods.changeAddress(contracts.MyToken.options.address).send();
+        },
+        deps: ["MyToken"]
       },
       ContractArgs: {
         args: {
@@ -94,6 +102,11 @@ describe("Token", function() {
 
     it("should use onDeploy", async function() {
       const result = await Test.methods.addr().call();
+      assert.strictEqual(result, MyToken.options.address);
+    });
+
+    it("should use onDeploy with function", async function() {
+      const result = await TestOnDeploy.methods.addr().call();
       assert.strictEqual(result, MyToken.options.address);
     });
 

--- a/packages/plugins/specialconfigs/src/functionConfigs.js
+++ b/packages/plugins/specialconfigs/src/functionConfigs.js
@@ -97,7 +97,7 @@ class FunctionConfigs {
     let args = { contracts: {}, logger};
     for (let contract of contracts) {
       // TODO: for this to work correctly we need to add a default from address to the contract
-      if (contract.deploy === false) continue;
+      if (contract.deploy === false || !contract.deployedAddress) continue;
       // eslint-disable-next-line no-await-in-loop
       let contractInstance = await this.events.request2("runcode:eval", contract.className);
       args.contracts[contract.className] = contractInstance;


### PR DESCRIPTION
When using a deploy hook function, we get the dependencies from the
vm but we didn't check first if the contract was deployed.

That meant that if a contract was not deployed and a contract that
deployed before it and had an onDeploy, the onDeploy would fail
because we tried to get that first undeployed contract as a dep and
it didn't exist

Also added a new test to test that case
