### PR TITLE
fix(@embark/whisper): p2p port is main command

### DIFF
--- a/packages/plugins/whisper-geth/src/whisperGethClient.js
+++ b/packages/plugins/whisper-geth/src/whisperGethClient.js
@@ -100,7 +100,6 @@ class WhisperGethClient {
 
   determineRpcOptions(config) {
     let cmd = [];
-    cmd.push("--port=30304");
     cmd.push("--rpc");
     cmd.push("--rpcport=9998");
     cmd.push("--rpcaddr=" + config.rpcHost);
@@ -157,6 +156,7 @@ class WhisperGethClient {
     let rpcApi = this.config.rpcApi;
     let wsApi = this.config.wsApi;
     let args = ['--ipcdisable']; // Add --ipcdisable as ipc is not needed for Whisper and it conflicts on Windows with the blockchain node
+    args.push("--port=30304");
     async.series([
       function commonOptions(callback) {
         let cmd = self.commonOptions();


### PR DESCRIPTION


### What did you refactor, implement, or fix?

Port was never being defined for whisper,  because it never called the rpc port config. 
This commit moves port flag to the main commands, so it's always included.

#### How did you do it?

Just moved where the flag is included.

#### Is there anything that needs special attention (breaking changes, etc)?

No

### Questions

Can we make p2p port part of main commands of embark/geth as well?


### Cool Spaceship Picture

![image](https://user-images.githubusercontent.com/224810/89657868-2843f580-d8a4-11ea-9d31-171428962f6e.png)

