### PR TITLE
fix: update to @dabh/colors for security vuln

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -52,7 +52,7 @@
     "@babel/runtime-corejs3": "7.8.4",
     "@types/deep-equal": "1.0.1",
     "async": "3.2.0",
-    "colors": "1.3.2",
+    "@dabh/colors": "1.3.2",
     "core-js": "3.4.3",
     "decompress": "4.2.0",
     "deep-equal": "1.0.1",


### PR DESCRIPTION
### What did you refactor, implement, or fix?

A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.


### Cool Spaceship Picture

🚀  😄 
